### PR TITLE
Remove the indirection used for calling k8s.TaintNode

### DIFF
--- a/internal/k8sapi/mock.go
+++ b/internal/k8sapi/mock.go
@@ -382,6 +382,26 @@ func (mock *K8sMock) TaintNode(ctx context.Context, nodeName, taintKey string, e
 	if mock.InducedErrors.TaintNode {
 		return errors.New("induced taint node error")
 	}
+	if node, err := mock.GetNode(ctx, nodeName); err == nil {
+		currentTaints := node.Spec.Taints
+		updatedTaints := make([]v1.Taint, 0)
+		for _, taint := range currentTaints {
+			if taint.Key != taintKey {
+				updatedTaints = append(updatedTaints, taint)
+			}
+		}
+		if !remove {
+			updatedTaints = append(updatedTaints, v1.Taint{
+				Key:    taintKey,
+				Value:  "",
+				Effect: effect,
+			})
+		}
+		node.Spec.Taints = updatedTaints
+	} else {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -425,9 +425,6 @@ func getCSINodeIDAnnotation(node *v1.Node, driverPath string) string {
 	return ""
 }
 
-//K8sTaint is a reference to a function that can update a node taint
-var K8sTaint = callK8sAPITaint
-
 func callK8sAPITaint(operation, nodeName, taintKey string, effect v1.TaintEffect, remove bool) error {
 	log.Infof("Calling to %s %s with %s %s (remove = %v)", operation, nodeName, taintKey, effect, remove)
 	ctx, cancel := K8sAPI.GetContext(MediumTimeout)
@@ -441,7 +438,7 @@ func taintNode(nodeName string, removeTaint bool) error {
 	if removeTaint {
 		operation = "untainting "
 	}
-	return K8sTaint(operation, nodeName, PodmonTaintKey, v1.TaintEffectNoSchedule, removeTaint)
+	return callK8sAPITaint(operation, nodeName, PodmonTaintKey, v1.TaintEffectNoSchedule, removeTaint)
 }
 
 func nodeHasTaint(node *v1.Node, key string, taintEffect v1.TaintEffect) bool {

--- a/internal/monitor/monitor_steps_test.go
+++ b/internal/monitor/monitor_steps_test.go
@@ -60,7 +60,6 @@ type feature struct {
 	pvNames                  []string    // For multi-volume tests
 	podCount                 int
 	failCSIVolumePathDirRead bool
-	failK8sTaint             bool
 	failRemoveDir            string
 	maxNodeAPILoopTimes      int
 	// If true and the test case has expected loghook.LastEntry set to
@@ -100,16 +99,8 @@ func (f *feature) aControllerMonitor(driver string) error {
 	f.podmonMonitor.CSIExtensionsPresent = true
 	f.podmonMonitor.DriverPathStr = "csi-vxflexos.dellemc.com"
 	gofsutil.UseMockFS()
-	K8sTaint = f.mockK8sTaint
 	RemoveDir = f.mockRemoveDir
 	f.badWatchObject = false
-	return nil
-}
-
-func (f *feature) mockK8sTaint(operation, name, taint string, effect v1.TaintEffect, remove bool) error {
-	if f.failK8sTaint {
-		return fmt.Errorf("mock failure: operation %s against %s with taint %s:%s remove=%v failed", operation, name, taint, effect, remove)
-	}
 	return nil
 }
 
@@ -239,7 +230,7 @@ func (f *feature) iInduceError(induced string) error {
 	case "CSIVolumePathDirRead":
 		f.failCSIVolumePathDirRead = true
 	case "K8sTaint":
-		f.failK8sTaint = true
+		f.k8sapiMock.InducedErrors.TaintNode = true
 	case "RemoveDir":
 		f.failRemoveDir = "Could not delete"
 	case "BadWatchObject":


### PR DESCRIPTION
# Description
We used to employ the kubectl CLI to taint nodes. In order to run unit tests, we came up with some indirections to mock out the tainting of nodes. Now that we're using k8s.TaintNode API call, we can remove this indirection. Changes are:

1. Remove taint call indirection.
2. Mock out k8s.TaintNode
3. Wire up k8s.TaintNode failure induction

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #20  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Unit tests were run.