### PR TITLE
Tar exec path in collect logs script needs a fix

### DIFF
--- a/tools/collect_logs.sh
+++ b/tools/collect_logs.sh
@@ -16,7 +16,7 @@
 ns=""
 podmon_label="podmon.dellemc.com/driver"
 CWD=$(pwd)
-
+TAR=$(which tar)
 CONTAINERS="podmon driver"
 
 for param in $*; do
@@ -86,8 +86,8 @@ TARNAME="$CWD/driver.logs.$TIMESTAMP.tgz"
 cd /tmp
 
 # Tar up the logs using the time stamp
-echo /usr/bin/tar -c -z -v -f  $TARNAME $DIRNAME
-/usr/bin/tar -c -z -v -f  $TARNAME $DIRNAME
+echo "$TAR" -c -z -v -f  $TARNAME $DIRNAME
+$TAR -c -z -v -f  $TARNAME $DIRNAME
 
 # Remove the temporary directory
 rm -rf $TEMPDIR


### PR DESCRIPTION
# Description
We need to determine the path of the tar exec to use for the collect logs script. When I ran it on my VM, it wasn't able to find the tar at the path specified in the script. I used `which` to determine the proper tar exec path and used that.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #37 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Ran the collection script on my VM, which previously did not work. With the changes it worked:

```
Collecting logs driver namespace %ns podmon label podmon.dellemc.com/driver
Using TEMPDIR /tmp/tmp.3hR6HCRItq
20210322_1233
pods vxflexos-controller-656445b49f-sqcdn vxflexos-node-6pkns vxflexos-node-lr94j
No resources found in pmtv2 namespace.
No resources found in pmtv2 namespace.
No resources found in pmtv2 namespace.
No resources found in pmtv2 namespace.
No resources found in pmtv2 namespace.
/bin/tar -c -z -v -f /workspace/karavi-resiliency/tools/driver.logs.20210322_1233.tgz tmp.3hR6HCRItq
tmp.3hR6HCRItq/
tmp.3hR6HCRItq/driver.pods.list
tmp.3hR6HCRItq/vxflexos.vxflexos-node-6pkns.driver.log
tmp.3hR6HCRItq/protected.pods.list
tmp.3hR6HCRItq/vxflexos.vxflexos-node-6pkns.podmon.log
tmp.3hR6HCRItq/vxflexos.vxflexos-controller-656445b49f-sqcdn.driver.log
tmp.3hR6HCRItq/vxflexos.vxflexos-node-lr94j.podmon.log
tmp.3hR6HCRItq/vxflexos.vxflexos-controller-656445b49f-sqcdn.podmon.log
tmp.3hR6HCRItq/vxflexos.vxflexos-node-lr94j.driver.log
```
