### PR TITLE
Remove token usage

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'dell/dell-csi-extensions'
-          token: ${{secrets.DELL_EMC_XT_TOKEN}}
           path: dell-csi-extensions
       - name: Run the formatter, linter, and vetter
         uses: dell/common-github-actions/go-code-formatter-linter-vetter@main
@@ -41,7 +40,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'dell/dell-csi-extensions'
-          token: ${{secrets.DELL_EMC_XT_TOKEN}}
           path: dell-csi-extensions
       - name: Run unit tests and check package coverage
         uses: dell/common-github-actions/go-code-tester@main
@@ -84,7 +82,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'dell/dell-csi-extensions'
-          token: ${{secrets.DELL_EMC_XT_TOKEN}}
           path: dell-csi-extensions
       - name: Install Mockgen
         run: go get github.com/golang/mock/mockgen@v1.4.4


### PR DESCRIPTION
# Description
A GitHub secret token is no longer required to access the dell-csi-extensions repo

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #61  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
This is a GitHub Actions specific change. Nothing related to the karavi-resiliency source is changed.