### PR TITLE
Openshift integration test

### DIFF
--- a/docs/INTEGRATION_TEST.md
+++ b/docs/INTEGRATION_TEST.md
@@ -24,6 +24,7 @@ These environmental variables need to be set:
 | SCRIPTS_DIR | Yes | The full path to the Karavi Resiliency test scripts from the machine that you are invoking the integration test. | For example if you've cloned the karavi-resiliency repo to /workspace/karavi-resiliency, then this value should be _/workspace/karavi-resiliency/test/sh_ | 
 | POLL_K8S | No |When enabled, will run a background poller that dumps status of the nodes and test pods.  | "true" |
 | RESILIENCY_INT_TEST_STOP_ON_FAILURE | No | By default the integration will be set to stop on any failure. Using this flag and setting it to 'false' will allow tests to continue on failure | default: "true", Set to "false" to disable |
+| OPENSHIFT_BASTION | If using Openshift - Yes, otherwise No | Name or IP address of the Openshift Bastion node. Openshift node failures will be invoked from this host. | Bastion node name/IP |
 
 # Running 
 

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -82,7 +82,7 @@ const (
 	// Directory where test scripts will be dropped
 	remoteScriptDir = "/root/karavi-resiliency-tests"
 	// Directory on Openshift nodes where the scripts will be dropped
-	openShiftRemoteScriptDir = "/tmp/karavi-resiliency-tests"
+	openShiftRemoteScriptDir = "/usr/tmp/karavi-resiliency-tests"
 	// An int value representing number of seconds to periodically check status
 	checkTickerInterval = 10
 	stopFilename        = "stop_test"
@@ -1003,7 +1003,7 @@ func (i *integration) copyOverTestScriptsToOpenshift(address string) error {
 	}
 
 	// Use SCP to copy the script files on the Bastion node into the /tmp dir of the Openshift node.
-	copyFileCmd := fmt.Sprintf("scp -r %s core@%s:%s", remoteScriptDir, address, "/tmp")
+	copyFileCmd := fmt.Sprintf("scp -r %s core@%s:%s", remoteScriptDir, address, "/usr/tmp")
 	log.Info(copyFileCmd)
 	err := client.Run(copyFileCmd)
 	if err != nil {


### PR DESCRIPTION
# Description
Update the integration tests to detect and work against Openshift clusters. A new environmental variable is required, which would have to point to the Bastion node. Test scripts will be first uploaded to the Bastion node, then to the individual Openshift nodes. Failure invocation is done from the Bastion node to the other Openshift nodes.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #13 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Ran the test pointing an Openshift cluster with the driver, resiliency enabled, and new env var set.
[openshift-test.log.txt](https://github.com/dell/karavi-resiliency/files/6307284/openshift-test.log.txt)

Ran Jenkins job that deploys upstream K8s and runs short integration test - Passed. https://__SIO3 Jenkins Instance__/job/Ecosystems_Novus/job/Karavi_Resiliency/view/Dev/job/podmon-integration-test/13