### PR TITLE
Update nettle and gnutls packages in resiliency image

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -3,5 +3,3 @@ general:
     # No fixes for these at this time
     - CVE-2019-25013
     - CVE-2019-5827
-    - CVE-2021-3450
-    - CVE-2021-20305

--- a/cmd/podmon/Dockerfile
+++ b/cmd/podmon/Dockerfile
@@ -1,4 +1,6 @@
 FROM registry.access.redhat.com/ubi8:8.3
 RUN dnf -y install openssl
+RUN dnf -y install nettle
+RUN dnf -y install gnutls
 COPY podmon /podmon
 ENTRYPOINT [ "/podmon" ]

--- a/cmd/podmon/Dockerfile
+++ b/cmd/podmon/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:8.3
-RUN dnf -y install openssl
-RUN dnf -y install nettle
-RUN dnf -y install gnutls
+RUN dnf -y install openssl && \
+    dnf -y install nettle && \
+    dnf -y install gnutls
 COPY podmon /podmon
 ENTRYPOINT [ "/podmon" ]


### PR DESCRIPTION
# Description
A couple CVEs have been fixed, thus we should update the resiliency Docker image to use the latest packages that have the fixes.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #66 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Manually ran trivy against a local instance of the Docker image with the changes:
```console
[root@xxxx ~]# trivy image --severity HIGH,CRITICAL --exit-code 1 xxxxx:5000/podmon:v0.2.0x
2021-04-19T16:58:52.890-0400    INFO    Need to update DB
2021-04-19T16:58:52.890-0400    INFO    Downloading DB...
20.84 MiB / 20.84 MiB [---------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 10.03 MiB p/s 2s
2021-04-19T16:59:04.377-0400    INFO    Detecting RHEL/CentOS vulnerabilities...
2021-04-19T16:59:04.385-0400    INFO    Trivy skips scanning programming language libraries because no supported file was detected

xxxx:5000/podmon:v0.2.0x (redhat 8.3)
=============================================
Total: 4 (HIGH: 4, CRITICAL: 0)

+------------------------+------------------+----------+-------------------+---------------+--------------------------------+
|        LIBRARY         | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+------------------------+------------------+----------+-------------------+---------------+--------------------------------+
| glibc                  | CVE-2019-25013   | HIGH     | 2.28-127.el8_3.2  |               | glibc: buffer over-read in     |
|                        |                  |          |                   |               | iconv when processing invalid  |
|                        |                  |          |                   |               | multi-byte input sequences     |
|                        |                  |          |                   |               | in...                          |
+------------------------+                  +          +                   +---------------+                                +
| glibc-common           |                  |          |                   |               |                                |
|                        |                  |          |                   |               |                                |
|                        |                  |          |                   |               |                                |
|                        |                  |          |                   |               |                                |
+------------------------+                  +          +                   +---------------+                                +
| glibc-minimal-langpack |                  |          |                   |               |                                |
|                        |                  |          |                   |               |                                |
|                        |                  |          |                   |               |                                |
|                        |                  |          |                   |               |                                |
+------------------------+------------------+          +-------------------+---------------+--------------------------------+
| sqlite-libs            | CVE-2019-5827    |          | 3.26.0-11.el8     |               | chromium-browser:              |
|                        |                  |          |                   |               | out-of-bounds access in SQLite |
+------------------------+------------------+----------+-------------------+---------------+--------------------------------+
```