### PR TITLE
Unity integration test1

### DIFF
--- a/internal/monitor/Makefile
+++ b/internal/monitor/Makefile
@@ -15,19 +15,26 @@ godog:
 gocover:
 	go tool cover -html=c.out
 
-integration-test:
+powerflex-integration-test:
 	RESILIENCY_INT_TEST="true" \
 	RESILIENCY_TEST_CLEANUP="true" \
 	K8S_POLL="true" \
 	SCRIPTS_DIR="../../test/sh" \
-	go test -timeout 2h -test.v -test.run "^\QTestFirstCheck\E|\QTestIntegration\E"
+	go test -timeout 2h -test.v -test.run "^\QTestPowerFlexFirstCheck\E|\QTestPowerFlexIntegration\E"
 
-short-integration-test:
+unity-integration-test:
+	RESILIENCY_INT_TEST="true" \
+	RESILIENCY_TEST_CLEANUP="true" \
+	K8S_POLL="true" \
+	SCRIPTS_DIR="../../test/sh" \
+	go test -timeout 6h -test.v -test.run "^\QTestUnityFirstCheck\E|\QTestUnityIntegration\E"
+
+powerflex-short-integration-test:
 	RESILIENCY_SHORT_INT_TEST="true" \
 	RESILIENCY_TEST_CLEANUP="true" \
 	K8S_POLL="true" \
 	SCRIPTS_DIR="../../test/sh" \
-	go test -timeout 2h -test.v -test.run "^\QTestShortCheck\E|\QTestShortIntegration\E"
+	go test -timeout 2h -test.v -test.run "^\QTestPowerFlexShortCheck\E|\QTestPowerFlexShortIntegration\E"
 
 unity-short-integration-test:
 	RESILIENCY_SHORT_INT_TEST="true" \

--- a/internal/monitor/Makefile
+++ b/internal/monitor/Makefile
@@ -28,3 +28,10 @@ short-integration-test:
 	K8S_POLL="true" \
 	SCRIPTS_DIR="../../test/sh" \
 	go test -timeout 2h -test.v -test.run "^\QTestShortCheck\E|\QTestShortIntegration\E"
+
+unity-short-integration-test:
+	RESILIENCY_SHORT_INT_TEST="true" \
+	RESILIENCY_TEST_CLEANUP="true" \
+	K8S_POLL="true" \
+	SCRIPTS_DIR="../../test/sh" \
+	go test -timeout 2h -test.v -test.run "^\QTestUnityShortCheck\E|\QTestUnityShortIntegration\E"

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -3,7 +3,7 @@ Feature: Integration Test
   I want to test CSM for Resiliency in a kubernetes environment
   So that it is known to work on various pod clean up cases and give consistent results
 
-  @int-setup-check
+  @powerflex-int-setup-check
   Scenario Outline: Validate that we have a valid k8s configuration for the integration tests
     Given a kubernetes <kubeConfig>
     And test environmental variables are set
@@ -16,8 +16,21 @@ Feature: Integration Test
       | kubeConfig | driverNames                | namespace  | name       | storageClasses          |
       | ""         | "csi-vxflexos.dellemc.com" | "vxflexos" | "vxflexos" | "vxflexos,vxflexos-xfs" |
 
+  @unity-int-setup-check
+  Scenario Outline: Validate that we have a valid k8s configuration for the integration tests
+    Given a kubernetes <kubeConfig>
+    And test environmental variables are set
+    And these CSI driver <driverNames> are configured on the system
+    And these storageClasses <storageClasses> exist in the cluster
+    And there is a <namespace> in the cluster
+    And there are driver pods in <namespace> with this <name> prefix
+    And can logon to nodes and drop test scripts
+    Examples:
+      | kubeConfig | driverNames                | namespace  | name       | storageClasses          |
+      | ""         | "csi-unity.dellemc.com"    | "unity"    | "unity"    | "unity,unity-nfs"       |
 
-  @integration
+
+  @powerflex-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
@@ -40,7 +53,7 @@ Feature: Integration Test
       | ""         | "3-5"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 240      | 240        | 300     | 600           |
       | ""         | "3-5"       | "4-4" | "4-4" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 240      | 240        | 300     | 600           |
 
-  @integration
+  @powerflex-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
@@ -63,7 +76,7 @@ Feature: Integration Test
       | ""         | "3-5"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 240      | 240        | 300     | 600           |
       | ""         | "3-5"       | "4-4" | "4-4" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 240      | 240        | 300     | 600           |
 
-  @integration
+  @powerflex-integration
   Scenario Outline: Deploy pods when there are failed nodes already
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
@@ -81,7 +94,7 @@ Feature: Integration Test
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300           |
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot"        | 120      | 240        | 300           |
 
-  @integration
+  @powerflex-integration
   Scenario Outline: Short failure window tests
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
@@ -97,7 +110,7 @@ Feature: Integration Test
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 45       | 240        | 120     | 300           |
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |
 
-  @short-integration
+  @powerflex-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
@@ -114,7 +127,24 @@ Feature: Integration Test
       | ""         | "1-1"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
       | ""         | "2-2"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 600           |
 
-  @short-integration
+  @unity-short-integration
+  Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity"      | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
+      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity"      | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 600           |
+
+  @powerflex-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
@@ -130,3 +160,20 @@ Feature: Integration Test
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
       | ""         | "1-1"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
       | ""         | "2-2"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
+
+  @unity-short-integration
+  Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity"      | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
+      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity"      | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -68,9 +68,9 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
       # Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
-      | ""         | "1-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
-      | ""         | "1-2"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
+      | ""         | "1-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
+      | ""         | "1-2"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
       # Slightly more pods, increasing number of vols and devs
       | ""         | "3-5"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
       | ""         | "3-5"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
@@ -91,9 +91,9 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
       # Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
-      | ""         | "1-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
-      | ""         | "1-2"       | "4-4" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
+      | ""         | "1-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
+      | ""         | "1-2"       | "4-4" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
       # Slightly more pods, increasing number of vols and devs
       | ""         | "3-5"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
       | ""         | "3-5"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
@@ -137,13 +137,13 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
       # Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
-      | ""         | "1-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
-      | ""         | "1-2"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 600        | 600     | 600           |
+      | ""         | "1-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 600        | 600     | 600           |
+      | ""         | "1-2"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 600        | 600     | 600           |
       # Slightly more pods, increasing number of vols and devs
-      | ""         | "3-5"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
-      | ""         | "3-5"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
-      | ""         | "3-5"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
+      | ""         | "3-5"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 600     | 600           |
+      | ""         | "3-5"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 600     | 600           |
+      | ""         | "3-5"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 600     | 600           |
 
   @unity-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
@@ -160,13 +160,13 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
       # Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
-      | ""         | "1-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
-      | ""         | "1-2"       | "4-4" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 600        | 600     | 600           |
+      | ""         | "1-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 600        | 600     | 600           |
+      | ""         | "1-2"       | "4-4" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 600        | 600     | 600           |
       # Slightly more pods, increasing number of vols and devs
-      | ""         | "3-5"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
-      | ""         | "3-5"       | "2-2" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
-      | ""         | "3-5"       | "4-4" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 900           |
+      | ""         | "3-5"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 600     | 600           |
+      | ""         | "3-5"       | "2-2" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 600     | 600           |
+      | ""         | "3-5"       | "4-4" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 600     | 900           |
 
 
   @powerflex-integration
@@ -252,8 +252,8 @@ Feature: Integration Test
     Then finally cleanup everything
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass    | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"   | "one-third" | "zero"  | "interfacedown" | 45       | 240        | 120     | 300           |
-      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"   | "one-third" | "zero"  | "interfacedown" | 45       | 600        | 300     | 300           |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"   | "one-third" | "zero"  | "reboot"        | 45       | 600        | 300     | 300           |
 
   @unity-integration
   Scenario Outline: Short failure window tests
@@ -268,8 +268,8 @@ Feature: Integration Test
     Then finally cleanup everything
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 45       | 240        | 120     | 300           |
-      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 45       | 600        | 300     | 300           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot"        | 45       | 600        | 300     | 300           |
 
   @powerflex-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
@@ -302,10 +302,10 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
-      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 300        | 300     | 600           |
-      | ""         | "1-1"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
-      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 300        | 300     | 600           |
+      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
+      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 600           |
+      | ""         | "1-1"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 300           |
+      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300     | 600           |
 
   @powerflex-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
@@ -338,7 +338,7 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
-      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 300        | 300     | 600           |
-      | ""         | "1-1"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
-      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 300        | 300     | 600           |
+      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 600        | 300     | 600           |
+      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 600        | 300     | 600           |
+      | ""         | "1-1"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 600        | 300     | 600           |
+      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 600        | 300     | 600           |

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -27,7 +27,7 @@ Feature: Integration Test
     And can logon to nodes and drop test scripts
     Examples:
       | kubeConfig | driverNames                | namespace  | name       | storageClasses          |
-      | ""         | "csi-unity.dellemc.com"    | "unity"    | "unity"    | "unity,unity-nfs"       |
+      | ""         | "csi-unity.dellemc.com"    | "unity"    | "unity"    | "unity-iscsi,unity-nfs" |
 
 
   @powerflex-integration
@@ -53,6 +53,52 @@ Feature: Integration Test
       | ""         | "3-5"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 240      | 240        | 300     | 600           |
       | ""         | "3-5"       | "4-4" | "4-4" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 240      | 240        | 300     | 600           |
 
+  @unity-integration
+  Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      # Small number of pods, increasing number of vols and devs
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      | ""         | "1-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      | ""         | "1-2"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      # Slightly more pods, increasing number of vols and devs
+      | ""         | "3-5"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
+      | ""         | "3-5"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
+      | ""         | "3-5"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 240      | 1500       | 300     | 600           |
+
+  @unity-integration
+  Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      # Small number of pods, increasing number of vols and devs
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      | ""         | "1-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      | ""         | "1-2"       | "4-4" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 400        | 300     | 300           |
+      # Slightly more pods, increasing number of vols and devs
+      | ""         | "3-5"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
+      | ""         | "3-5"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 300     | 600           |
+      | ""         | "3-5"       | "4-4" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 240      | 1500       | 300     | 600           |
+
   @powerflex-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
     Given a kubernetes <kubeConfig>
@@ -76,6 +122,53 @@ Feature: Integration Test
       | ""         | "3-5"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 240      | 240        | 300     | 600           |
       | ""         | "3-5"       | "4-4" | "4-4" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 240      | 240        | 300     | 600           |
 
+  @unity-integration
+  Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      # Small number of pods, increasing number of vols and devs
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      | ""         | "1-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      | ""         | "1-2"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      # Slightly more pods, increasing number of vols and devs
+      | ""         | "3-5"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
+      | ""         | "3-5"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
+      | ""         | "3-5"       | "4-4" | "4-4" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
+
+  @unity-integration
+  Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      # Small number of pods, increasing number of vols and devs
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      | ""         | "1-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      | ""         | "1-2"       | "4-4" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 120      | 400        | 300     | 600           |
+      # Slightly more pods, increasing number of vols and devs
+      | ""         | "3-5"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
+      | ""         | "3-5"       | "2-2" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 600           |
+      | ""         | "3-5"       | "4-4" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot" | 240      | 1500       | 300     | 900           |
+
+
   @powerflex-integration
   Scenario Outline: Deploy pods when there are failed nodes already
     Given a kubernetes <kubeConfig>
@@ -94,6 +187,42 @@ Feature: Integration Test
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300           |
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot"        | 120      | 240        | 300           |
 
+  @unity-integration
+  Scenario Outline: Deploy pods when there are failed nodes already
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    Then finally cleanup everything
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | nodeCleanSecs |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"| "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300           |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"| "one-third" | "zero"  | "reboot"        | 120      | 600        | 300           |
+
+  @unity-integration
+  Scenario Outline: Deploy pods when there are failed nodes already
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    Then finally cleanup everything
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | nodeCleanSecs |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 300           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot"        | 120      | 600        | 300           |
+
   @powerflex-integration
   Scenario Outline: Short failure window tests
     Given a kubernetes <kubeConfig>
@@ -109,6 +238,38 @@ Feature: Integration Test
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 45       | 240        | 120     | 300           |
       | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |
+
+  @unity-integration
+  Scenario Outline: Short failure window tests
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass    | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"   | "one-third" | "zero"  | "interfacedown" | 45       | 240        | 120     | 300           |
+      | ""         | "1-2"       | "1-1" | "1-1" | "unity"    | "unity-iscsi"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |
+
+  @unity-integration
+  Scenario Outline: Short failure window tests
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
+    Then validate that all pods are running within <deploySecs> seconds
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 45       | 240        | 120     | 300           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |
 
   @powerflex-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
@@ -140,9 +301,11 @@ Feature: Integration Test
     Then finally cleanup everything
 
     Examples:
-      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity"      | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
-      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity"      | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 600           |
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
+      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 300        | 300     | 600           |
+      | ""         | "1-1"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
+      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 300        | 300     | 600           |
 
   @powerflex-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
@@ -174,6 +337,8 @@ Feature: Integration Test
     Then finally cleanup everything
 
     Examples:
-      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity"      | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
-      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity"      | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | ""         | "1-1"       | "1-1" | "1-1" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
+      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 300        | 300     | 600           |
+      | ""         | "1-1"       | "1-1" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
+      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 300        | 300     | 600           |

--- a/internal/monitor/features/node.feature
+++ b/internal/monitor/features/node.feature
@@ -46,7 +46,6 @@ Feature: Controller Monitor
       | "node1"  | 1    | "node1" | "DELETED"  | 0       | "none"                | "none"                      |
 
   @node-mode
-  @wip
   Scenario Outline: Testing monitor.nodeModeCleanupPods
     Given a controller monitor <driver>
     And node <nodeName> env vars set

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -268,6 +268,9 @@ func (i *integration) failWorkerAndPrimaryNodes(numNodes, numPrimary, failure st
 		return err
 	}
 
+	// Allow a little extra for node failure to be detected than just the node down time.
+	// This proved necessary for the really short failure times (45 sec.) to be reliable.
+	wait = wait + wait
 	log.Infof("Requested nodes to fail. Waiting up to %d seconds to see if they show up as failed.", wait)
 	timeoutDuration := time.Duration(wait) * time.Second
 	timeout := time.NewTimer(timeoutDuration)
@@ -371,8 +374,8 @@ func (i *integration) deployPods(podsPerNode, numVols, numDevs, driverType, stor
 	args := []string{
 		deployScriptPath,
 		"--instances", strconv.Itoa(podCount),
-		"--ndevices", strconv.Itoa(volCount),
-		"--nvolumes", strconv.Itoa(devCount),
+		"--nvolumes", strconv.Itoa(volCount),
+		"--ndevices", strconv.Itoa(devCount),
 		"--prefix", i.testNamespacePrefix,
 		"--storage-class", storageClass,
 	}
@@ -799,8 +802,8 @@ func (i *integration) selectFromRange(rangeValue string) (int, error) {
 		return -1, fmt.Errorf("invalid range. Minimum is less than 1 (%d)", min)
 	}
 
-	if max < 1 {
-		return -1, fmt.Errorf("invalid range. Maximum is less than 1 (%d)", max)
+	if max < 0 {
+		return -1, fmt.Errorf("invalid range. Maximum is less than 0 (%d)", max)
 	}
 
 	if min > max {
@@ -1064,7 +1067,7 @@ func (i *integration) induceFailureOn(name string, ip, failureType string, wait 
 		Timeout:    sshTimeout,
 	}
 
-	log.Infof("Attempting to induce the %s failure on %s/%s and waiting %d seconds", failureType, name, ip, wait)
+	log.Infof("Attempting to induce the %s failure on %s/%s for %d seconds", failureType, name, ip, wait)
 	scriptToUse, ok := failureToScriptMap[failureType]
 	if !ok {
 		return fmt.Errorf("no mapping for failureType %s", failureType)

--- a/internal/monitor/integration_test.go
+++ b/internal/monitor/integration_test.go
@@ -27,7 +27,7 @@ var setupIsGood = false
 // stopOnFailure enabled means any failed tests would stop the tests (default: true)
 var stopOnFailure = true
 
-func TestFirstCheck(t *testing.T) {
+func TestPowerFlexFirstCheck(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableIntTestVar)
 	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
 		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableIntTestVar)
@@ -59,7 +59,7 @@ func TestFirstCheck(t *testing.T) {
 	log.Printf("Integration setup check finished")
 }
 
-func UnityTestFirstCheck(t *testing.T) {
+func TestUnityFirstCheck(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableIntTestVar)
 	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
 		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableIntTestVar)
@@ -91,8 +91,7 @@ func UnityTestFirstCheck(t *testing.T) {
 	log.Printf("Integration setup check finished")
 }
 
-
-func TestIntegration(t *testing.T) {
+func TestPowerFlexIntegration(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableIntTestVar)
 	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
 		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableIntTestVar)
@@ -117,6 +116,44 @@ func TestIntegration(t *testing.T) {
 		Format:        "pretty",
 		Paths:         []string{"features"},
 		Tags:          "powerflex-integration",
+		StopOnFailure: stopOnFailure,
+	}
+	status := godog.TestSuite{
+		Name:                "integration",
+		ScenarioInitializer: IntegrationTestScenarioInit,
+		Options:             &godogOptions,
+	}.Run()
+	if status != 0 {
+		t.Error("There were failed integration tests")
+	}
+	log.Printf("Integration test finished")
+}
+
+func TestUnityIntegration(t *testing.T) {
+	intTestEnvVarStr := os.Getenv(enableIntTestVar)
+	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
+		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableIntTestVar)
+		return
+	}
+
+	if !setupIsGood {
+		message := "The setup check failed. Tests skipped"
+		log.Printf(message)
+		t.Errorf(message)
+		return
+	}
+
+	stopOnFailureStr := os.Getenv(enableStopOnFailure)
+	if stopOnFailureStr != "" && strings.ToLower(stopOnFailureStr) == "false" {
+		stopOnFailure = false
+	}
+	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
+
+	log.Printf("Starting integration test")
+	godogOptions := godog.Options{
+		Format:        "pretty",
+		Paths:         []string{"features"},
+		Tags:          "unity-integration",
 		StopOnFailure: stopOnFailure,
 	}
 	status := godog.TestSuite{

--- a/internal/monitor/integration_test.go
+++ b/internal/monitor/integration_test.go
@@ -43,7 +43,7 @@ func TestFirstCheck(t *testing.T) {
 	godogOptions := godog.Options{
 		Format:        "pretty",
 		Paths:         []string{"features"},
-		Tags:          "int-setup-check",
+		Tags:          "powerflex-int-setup-check",
 		StopOnFailure: stopOnFailure,
 	}
 	status := godog.TestSuite{
@@ -58,6 +58,39 @@ func TestFirstCheck(t *testing.T) {
 	}
 	log.Printf("Integration setup check finished")
 }
+
+func UnityTestFirstCheck(t *testing.T) {
+	intTestEnvVarStr := os.Getenv(enableIntTestVar)
+	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
+		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableIntTestVar)
+		return
+	}
+
+	stopOnFailureStr := os.Getenv(enableStopOnFailure)
+	if stopOnFailureStr != "" && strings.ToLower(stopOnFailureStr) == "false" {
+		stopOnFailure = false
+	}
+	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
+
+	godogOptions := godog.Options{
+		Format:        "pretty",
+		Paths:         []string{"features"},
+		Tags:          "unity-int-setup-check",
+		StopOnFailure: stopOnFailure,
+	}
+	status := godog.TestSuite{
+		Name:                "integration",
+		ScenarioInitializer: IntegrationTestScenarioInit,
+		Options:             &godogOptions,
+	}.Run()
+	if status != 0 {
+		t.Skip("Integration setup check failed")
+	} else {
+		setupIsGood = true
+	}
+	log.Printf("Integration setup check finished")
+}
+
 
 func TestIntegration(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableIntTestVar)
@@ -83,7 +116,7 @@ func TestIntegration(t *testing.T) {
 	godogOptions := godog.Options{
 		Format:        "pretty",
 		Paths:         []string{"features"},
-		Tags:          "integration",
+		Tags:          "powerflex-integration",
 		StopOnFailure: stopOnFailure,
 	}
 	status := godog.TestSuite{

--- a/internal/monitor/short_integration_test.go
+++ b/internal/monitor/short_integration_test.go
@@ -21,7 +21,7 @@ import (
 
 const enableShortIntTestVar = "RESILIENCY_SHORT_INT_TEST"
 
-func TestShortCheck(t *testing.T) {
+func TestPowerFlexShortCheck(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableShortIntTestVar)
 	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
 		log.Printf("Skipping short integration test. To enable short integration test: export %s=true", enableShortIntTestVar)
@@ -85,7 +85,7 @@ func TestUnityShortCheck(t *testing.T) {
 	log.Printf("Integration setup check finished")
 }
 
-func TestShortIntegration(t *testing.T) {
+func TestPowerFlexShortIntegration(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableShortIntTestVar)
 	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
 		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableShortIntTestVar)

--- a/internal/monitor/short_integration_test.go
+++ b/internal/monitor/short_integration_test.go
@@ -37,7 +37,39 @@ func TestShortCheck(t *testing.T) {
 	godogOptions := godog.Options{
 		Format:        "pretty",
 		Paths:         []string{"features"},
-		Tags:          "int-setup-check",
+		Tags:          "powerflex-int-setup-check",
+		StopOnFailure: stopOnFailure,
+	}
+	status := godog.TestSuite{
+		Name:                "integration",
+		ScenarioInitializer: IntegrationTestScenarioInit,
+		Options:             &godogOptions,
+	}.Run()
+	if status != 0 {
+		t.Skip("Integration setup check failed")
+	} else {
+		setupIsGood = true
+	}
+	log.Printf("Integration setup check finished")
+}
+
+func TestUnityShortCheck(t *testing.T) {
+	intTestEnvVarStr := os.Getenv(enableShortIntTestVar)
+	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
+		log.Printf("Skipping short integration test. To enable short integration test: export %s=true", enableShortIntTestVar)
+		return
+	}
+
+	stopOnFailureStr := os.Getenv(enableStopOnFailure)
+	if stopOnFailureStr != "" && strings.ToLower(stopOnFailureStr) == "false" {
+		stopOnFailure = false
+	}
+	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
+
+	godogOptions := godog.Options{
+		Format:        "pretty",
+		Paths:         []string{"features"},
+		Tags:          "unity-int-setup-check",
 		StopOnFailure: stopOnFailure,
 	}
 	status := godog.TestSuite{
@@ -77,7 +109,45 @@ func TestShortIntegration(t *testing.T) {
 	godogOptions := godog.Options{
 		Format:        "pretty",
 		Paths:         []string{"features"},
-		Tags:          "short-integration",
+		Tags:          "powerflex-short-integration",
+		StopOnFailure: stopOnFailure,
+	}
+	status := godog.TestSuite{
+		Name:                "integration",
+		ScenarioInitializer: IntegrationTestScenarioInit,
+		Options:             &godogOptions,
+	}.Run()
+	if status != 0 {
+		t.Error("There were failed integration tests")
+	}
+	log.Printf("Integration test finished")
+}
+
+func TestUnityShortIntegration(t *testing.T) {
+	intTestEnvVarStr := os.Getenv(enableShortIntTestVar)
+	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
+		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableShortIntTestVar)
+		return
+	}
+
+	if !setupIsGood {
+		message := "The setup check failed. Tests skipped"
+		log.Printf(message)
+		t.Errorf(message)
+		return
+	}
+
+	stopOnFailureStr := os.Getenv(enableStopOnFailure)
+	if stopOnFailureStr != "" && strings.ToLower(stopOnFailureStr) == "false" {
+		stopOnFailure = false
+	}
+	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
+
+	log.Printf("Starting integration test")
+	godogOptions := godog.Options{
+		Format:        "pretty",
+		Paths:         []string{"features"},
+		Tags:          "unity-short-integration",
 		StopOnFailure: stopOnFailure,
 	}
 	status := godog.TestSuite{


### PR DESCRIPTION
# Description
This refactors the integration test, which previously only ran for PowerFlex, to also support Unity with makefile targets powerflex-integration-test, unity-integration-test, powerflex-short-integration-test, unity-short-integration-test.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes  (no code changes to driver or unit test)
- [x ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
* PowerFlex integration test: *
release "pmtv1" uninstalled
namespace "pmtv1" deleted
      | ""         | "1-2"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot"        | 45       | 240        | 120     | 300           |

16 scenarios (16 passed)
148 steps (148 passed)
1h41m26.402921275s
time="2021-05-07T19:20:15-04:00" level=info msg="Integration test finished"
--- PASS: TestPowerFlexIntegration (6086.44s)
PASS
status 0
ok      podmon/internal/monitor 6094.111s

* Unity integration test: *
namespace "pmtu2" deleted
namespace "pmtu1" deleted
      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"  | "one-third" | "zero"  | "reboot"        | 45       | 600        | 300     | 300           |

32 scenarios (32 passed)
296 steps (296 passed)
4h16m8.857508328s
time="2021-05-12T18:44:33-04:00" level=info msg="Integration test finished"
--- PASS: TestUnityIntegration (15368.88s)
PASS
status 0
ok      podmon/internal/monitor 15376.280s

NOTE: Unity has 32 scenarios because it runs each test on iSCSI and NFS. PowerFlex only has the SDC IP protocol.