### PR TITLE
Remove reboot test case for unity quick sanity.

### DIFF
--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -358,23 +358,6 @@ Feature: Integration Test
       | ""         | "1-1"       | "1-1" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
       | ""         | "2-2"       | "2-2" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 120      | 240        | 300     | 600           |
 
-  @unity-short-integration
-  Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
-    Given a kubernetes <kubeConfig>
-    And cluster is clean of test pods
-    And wait <nodeCleanSecs> to see there are no taints
-    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs>
-    Then validate that all pods are running within <deploySecs> seconds
-    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
-    Then validate that all pods are running within <runSecs> seconds
-    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
-    Then finally cleanup everything
-
-    Examples:
-      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "2-2"       | "2-2" | "2-2" | "unity"    | "unity-iscsi" | "one-third" | "zero"  | "reboot" | 120      | 600        | 300     | 600           |
-      | ""         | "2-2"       | "2-2" | "0-0" | "unity"    | "unity-nfs"   | "one-third" | "zero"  | "reboot" | 120      | 600        | 300     | 600           |
-
   @powerflex-array-interface
   Scenario Outline: Multi networked nodes with a failure against the array interface network
     Given a kubernetes <kubeConfig>


### PR DESCRIPTION
# Description
Unity quick integration test is further streamlined, by removing the 'reboot' test cases.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #22  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Run internal Jenkins job to run tests against unity; was able to complete successfully.