### PR TITLE
Check for node change after a failure.

### DIFF
--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -39,6 +39,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -62,6 +63,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -85,6 +87,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -108,6 +111,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -131,6 +135,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -154,6 +159,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -232,6 +238,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
     Examples:
@@ -249,6 +256,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -267,6 +275,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -284,6 +293,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
     Examples:
@@ -300,6 +310,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
     Examples:
@@ -316,6 +327,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -333,6 +345,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -350,6 +363,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -367,6 +381,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> and I expect these taints <taints>
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 
@@ -384,6 +399,7 @@ Feature: Integration Test
     Then validate that all pods are running within <deploySecs> seconds
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> and I expect these taints <taints>
     Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
     Then finally cleanup everything
 


### PR DESCRIPTION
# Description
This PR is an improvement for the e2e test. It will not validate that the pods that were failed over actually changed nodes. If not, the test will fail.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #13 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Ran the short-integration test locally.