### PR TITLE
Use --no-cache with docker build

### DIFF
--- a/cmd/podmon/Makefile
+++ b/cmd/podmon/Makefile
@@ -12,7 +12,7 @@ build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -a -ldflags '-w' ./...
 
 docker:
-	docker build  -t "$(REGISTRY):$(VERSION)" --label commit=$(shell git log --max-count 1 --format="%H") .
+	docker build --no-cache -t "$(REGISTRY):$(VERSION)" --label commit=$(shell git log --max-count 1 --format="%H") .
 
 push:
 	docker push "$(REGISTRY):$(VERSION)"


### PR DESCRIPTION
# Description
The docker build command in the Makefile should use the --no-cache option to make sure all the layers are rebuilt. This is to insure that the layer updating the dependencies gets rebuilt to pull the latest versions.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #90  |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
This is build related and no functional code has been updated.
