### PR TITLE
Update Resiliency base image to 8.4

### DIFF
--- a/cmd/podmon/Dockerfile
+++ b/cmd/podmon/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:8.3
+FROM registry.access.redhat.com/ubi8:8.4
 LABEL vendor="Dell Inc." \
       name="csm-resiliency" \
       summary="Dell EMC Container Storage Modules (CSM) for Resiliency" \


### PR DESCRIPTION
# Description

Update the CSM Podmon base image to latest version 8.4

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
Run CSM Podmon integration with CSI Drivers for PowerFlex and PowerScale version 2.0.0

- [ ] Test B
Run CSM Podmon integration with CSI Drivers for PowerFlex and PowerScale version latest
