### PR TITLE
Changes for deployment node affinity sharing volumes

### DIFF
--- a/test/podmontest/deploy/templates/test.yaml
+++ b/test/podmontest/deploy/templates/test.yaml
@@ -17,18 +17,18 @@ metadata:
 spec:
     selector:
         matchLabels:
-          app: podmontest
+          app: podmontest-{{ .Release.Namespace }}
 
 {{- if eq .Values.podmonTest.deploymentType "statefulset" }}
     serviceName: 2vols
 {{ end }}
 {{- if eq .Values.podmonTest.deploymentType "deployment" }}
-    replicas: 1
+    replicas: {{ required "Number of replicas" .Values.podmonTest.replicas }}
 {{ end }}
     template:
       metadata:
         labels:
-          app: podmontest
+          app: podmontest-{{ .Release.Namespace }}
           podmon.dellemc.com/driver: {{ required "Must set driver label" .Values.podmonTest.driverLabel }}
       spec:
 {{- if ne .Values.podmonTest.zone "" }}
@@ -41,6 +41,18 @@ spec:
                   operator: In
                   values: 
                   - {{.Values.podmonTest.zone}}
+{{end}}
+{{- if eq .Values.podmonTest.podAffinity "true"}}
+        affinity:
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values: 
+                  - podmontest-{{ .Release.Namespace }}
+              topologyKey: "kubernetes.io/hostname"
 {{end}}
         serviceAccount: podmontest
         containers:

--- a/test/podmontest/deploy/templates/test.yaml
+++ b/test/podmontest/deploy/templates/test.yaml
@@ -22,7 +22,7 @@ spec:
 {{- if eq .Values.podmonTest.deploymentType "statefulset" }}
     serviceName: 2vols
 {{ end }}
-{{- if eq .Values.podmonTest.deploymentType "deployment" }}
+{{- if gt .Values.podmonTest.replicas 1 }}
     replicas: {{ required "Number of replicas" .Values.podmonTest.replicas }}
 {{ end }}
     template:
@@ -42,7 +42,7 @@ spec:
                   values: 
                   - {{.Values.podmonTest.zone}}
 {{end}}
-{{- if eq .Values.podmonTest.podAffinity "true"}}
+{{- if eq .Values.podmonTest.podAffinity true}}
         affinity:
           podAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/podmontest/deploy/values-unity-nfs.yaml
+++ b/test/podmontest/deploy/values-unity-nfs.yaml
@@ -7,7 +7,7 @@ podmonTest:
   ndevices: 0
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
-  # replicas is the number of replicas for deployments or statefulset
+  # replicas is the number of replicas for deployments or statefulsets
   replicas: 1
   # set to "true" to locate replicates on the same node
   podAffinity: "false"

--- a/test/podmontest/deploy/values-unity-nfs.yaml
+++ b/test/podmontest/deploy/values-unity-nfs.yaml
@@ -4,12 +4,12 @@ podmonTest:
   driverLabel: csi-unity
   storageClassName: unity-virt21048j9rzz-nfs
   nvolumes: 2
-  ndevices: 2
+  ndevices: 0
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
-  # replicas is the number of replicas for deployments
-  replicas: 4
+  # replicas is the number of replicas for deployments or statefulset
+  replicas: 1
   # set to "true" to locate replicates on the same node
-  podAffinity: "true"
+  podAffinity: "false"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""

--- a/test/podmontest/deploy/values-unity-nfs.yaml
+++ b/test/podmontest/deploy/values-unity-nfs.yaml
@@ -7,5 +7,9 @@ podmonTest:
   ndevices: 2
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
+  # replicas is the number of replicas for deployments
+  replicas: 4
+  # set to "true" to locate replicates on the same node
+  podAffinity: "true"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""

--- a/test/podmontest/deploy/values-unity.yaml
+++ b/test/podmontest/deploy/values-unity.yaml
@@ -7,7 +7,7 @@ podmonTest:
   ndevices: 1
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
-  # replicas is the number of replicas for deployments or statefulset
+  # replicas is the number of replicas for deployments or statefulsets
   replicas: 1
   # set to "true" to locate replicates on the same node
   podAffinity: "false"

--- a/test/podmontest/deploy/values-unity.yaml
+++ b/test/podmontest/deploy/values-unity.yaml
@@ -7,9 +7,9 @@ podmonTest:
   ndevices: 1
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
-  # replicas is the number of replicas for deployments
-  replicas: 4
+  # replicas is the number of replicas for deployments or statefulset
+  replicas: 1
   # set to "true" to locate replicates on the same node
-  podAffinity: "true"
+  podAffinity: "false"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""

--- a/test/podmontest/deploy/values-unity.yaml
+++ b/test/podmontest/deploy/values-unity.yaml
@@ -7,5 +7,9 @@ podmonTest:
   ndevices: 1
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
+  # replicas is the number of replicas for deployments
+  replicas: 4
+  # set to "true" to locate replicates on the same node
+  podAffinity: "true"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""

--- a/test/podmontest/deploy/values-vxflex.yaml
+++ b/test/podmontest/deploy/values-vxflex.yaml
@@ -4,12 +4,12 @@ podmonTest:
   driverLabel: csi-vxflexos
   storageClassName: vxflexos-notopo
   nvolumes: 2
-  ndevices: 2
+  ndevices: 0
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
-  # replicas is the number of replicas for deployments
-  replicas: 8
+  # replicas is the number of replicas for deployments or deployments
+  replicas: 1
   # set to "true" to locate replicates on the same node
-  podAffinity: "true"
+  podAffinity: "false"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""

--- a/test/podmontest/deploy/values-vxflex.yaml
+++ b/test/podmontest/deploy/values-vxflex.yaml
@@ -7,7 +7,7 @@ podmonTest:
   ndevices: 0
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
-  # replicas is the number of replicas for deployments or deployments
+  # replicas is the number of replicas for deployments or statefulsets
   replicas: 1
   # set to "true" to locate replicates on the same node
   podAffinity: "false"

--- a/test/podmontest/deploy/values-vxflex.yaml
+++ b/test/podmontest/deploy/values-vxflex.yaml
@@ -7,5 +7,9 @@ podmonTest:
   ndevices: 2
   # deploymentType can be "statefulset" or "deployment"
   deploymentType: statefulset
+  # replicas is the number of replicas for deployments
+  replicas: 8
+  # set to "true" to locate replicates on the same node
+  podAffinity: "true"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""

--- a/test/podmontest/insu.sh
+++ b/test/podmontest/insu.sh
@@ -20,6 +20,7 @@ image="$REGISTRY_HOST:$REGISTRY_PORT/podmontest:v0.0.54"
 prefix="pmtu"
 deploymentType="statefulset"
 driverLabel="csi-unity"
+podAffinity="false"
 
 if [ "$DEBUG"x != "x" ]; then
   DEBUG="--dry-run --debug"
@@ -53,6 +54,15 @@ do
           storageClassName=$1
           shift
           ;;
+       "--replicas")
+          shift
+          replicas=$1
+          shift
+          ;;
+       "--podAffinity")
+          podAffinity="true"
+          shift
+          ;;
        "--deployment")
           deploymentType="deployment"
           shift
@@ -79,6 +89,8 @@ while [ $i -le $instances ]; do
               --set podmonTest.ndevices=$ndevices \
               --set podmonTest.nvolumes=$nvolumes \
               --set podmonTest.deploymentType=$deploymentType \
+              --set podmonTest.replicas=$replicas \
+              --set podmonTest.podAffinity=$podAffinity \
               --set podmonTest.image="$image" \
               --set podmonTest.zone="$zone" \
               --set podmonTest.driverLabel="$driverLabel"

--- a/test/podmontest/insv.sh
+++ b/test/podmontest/insv.sh
@@ -18,8 +18,10 @@ zone=${zone:-""}
 storageClassName=${storageClassName:-vxflexos-retain}
 image="$REGISTRY_HOST:$REGISTRY_PORT/podmontest:v0.0.54"
 prefix="pmtv"
+replicas=1
 deploymentType="statefulset"
 driverLabel="csi-vxflexos"
+podAffinity="false"
 
 if [ "$DEBUG"x != "x" ]; then
   DEBUG="--dry-run --debug"
@@ -53,6 +55,15 @@ do
           storageClassName=$1
           shift
           ;;
+       "--replicas")
+          shift
+	  replicas=$1
+	  shift
+	  ;;
+       "--podAffinity")
+          podAffinity="true"
+          shift
+	  ;;
        "--deployment")
           deploymentType="deployment"
           shift
@@ -79,6 +90,8 @@ while [ $i -le $instances ]; do
               --set podmonTest.ndevices=$ndevices \
               --set podmonTest.nvolumes=$nvolumes \
               --set podmonTest.deploymentType=$deploymentType \
+              --set podmonTest.replicas=$replicas \
+              --set podmonTest.podAffinity=$podAffinity \
               --set podmonTest.image="$image" \
               --set podmonTest.zone="$zone" \
               --set podmonTest.driverLabel="$driverLabel"

--- a/test/podmontest/uns.sh
+++ b/test/podmontest/uns.sh
@@ -13,6 +13,7 @@
 instances=${instances:-4}
 prefix="pmt"
 remove_all=""
+start=${start:-1}
 
 for param in $*
 do
@@ -32,6 +33,11 @@ do
           remove_all=$1
           shift
           ;;
+       "--start")
+          shift
+          start=$1
+          shift
+          ;;
     esac
 done
 
@@ -39,7 +45,7 @@ if [ "$remove_all"x != "x" ]; then
   instances=$(kubectl get pods -l "podmon.dellemc.com/driver=csi-${remove_all}" -A | grep -c "$prefix")
 fi
 
-i=1
+i=$start
 while [ $i -le $instances ]; do
   helm delete -n "${prefix}"$i "${prefix}"$i &
   i=$((i + 1))


### PR DESCRIPTION
# Description
This PR is primarily changes to the podmontest deployment script, to support node affinity show we can test volumes shared among multiple pods in deployment mode.
There are no go code changes. There are a couple of minor test script enhancements.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x ] I have not allowed coverage numbers to degenerate
- [x ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x ] Run the podmontest helm chart in deployment and observe volumes are shared between multiple pods on the same node.
- [ ] Test B
