### PR TITLE
Tom/test enhancements

### DIFF
--- a/internal/criapi/criapi_test.go
+++ b/internal/criapi/criapi_test.go
@@ -1,4 +1,5 @@
-//+build k8s
+//go:build k8s
+// +build k8s
 
 /*
  * Copyright (c) 2021. Dell Inc., or its subsidiaries. All Rights Reserved.

--- a/internal/utils/linuxUnmount.go
+++ b/internal/utils/linuxUnmount.go
@@ -1,3 +1,4 @@
+//go:build test || linux
 // +build test linux
 
 /*

--- a/internal/utils/winUnmount.go
+++ b/internal/utils/winUnmount.go
@@ -1,4 +1,5 @@
-//+build test windows
+//go:build test || windows
+// +build test windows
 
 /*
  * Copyright (c) 2021. Dell Inc., or its subsidiaries. All Rights Reserved.

--- a/test/podmontest/deploy/templates/test.yaml
+++ b/test/podmontest/deploy/templates/test.yaml
@@ -55,10 +55,14 @@ spec:
                   - podmontest-{{ .Release.Namespace }}
               topologyKey: "kubernetes.io/hostname"
 {{end}}
+        tolerations:
+          - effect: NoExecute
+            key: node.kubernetes.io/unreachable
+            operator: Exists
+            tolerationSeconds: {{ required "Number of seconds to tolerate unreachable taint" .Values.podmonTest.unreachableTolerationSeconds }}
         topologySpreadConstraints:
           - maxSkew: {{ required "Number of replicas" .Values.podmonTest.replicas }} #
             topologyKey: kubernetes.io/hostname
-        #    whenUnsatisfiable: ScheduleAnyway
             whenUnsatisfiable: DoNotSchedule
             labelSelector:
               matchLabels:

--- a/test/podmontest/deploy/values-unity-nfs.yaml
+++ b/test/podmontest/deploy/values-unity-nfs.yaml
@@ -13,3 +13,5 @@ podmonTest:
   podAffinity: "false"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""
+  # Number of seconds to tolerate a node unreachable taint
+  unreachableTolerationSeconds: 300

--- a/test/podmontest/deploy/values-unity.yaml
+++ b/test/podmontest/deploy/values-unity.yaml
@@ -13,3 +13,5 @@ podmonTest:
   podAffinity: "false"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""
+  # Number of seconds to tolerate a node unreachable taint
+  unreachableTolerationSeconds: 300

--- a/test/podmontest/deploy/values-vxflex.yaml
+++ b/test/podmontest/deploy/values-vxflex.yaml
@@ -13,3 +13,5 @@ podmonTest:
   podAffinity: "false"
   # zone will restrict node placement by matching node label failure-domain.beta.kubernetes.io/zone
   zone: ""
+  # Number of seconds to tolerate a node unreachable taint
+  unreachableTolerationSeconds: 300

--- a/test/podmontest/insu.sh
+++ b/test/podmontest/insu.sh
@@ -22,6 +22,7 @@ replicas=1
 deploymentType="statefulset"
 driverLabel="csi-unity"
 podAffinity="false"
+unreachableTolerationSeconds=300
 
 if [ "$DEBUG"x != "x" ]; then
   DEBUG="--dry-run --debug"
@@ -68,6 +69,10 @@ do
           deploymentType="deployment"
           shift
           ;;
+       "--unreachableTolerationSeconds")
+          shift
+          unreachableTolerationSeconds=$1
+          shift
        "--label")
           shift
           driverLabel=$1
@@ -92,6 +97,7 @@ while [ $i -le $instances ]; do
               --set podmonTest.deploymentType=$deploymentType \
               --set podmonTest.replicas=$replicas \
               --set podmonTest.podAffinity=$podAffinity \
+              --set podmonTest.unreachableTolerationSeconds=$unreachableTolerationSeconds \
               --set podmonTest.image="$image" \
               --set podmonTest.zone="$zone" \
               --set podmonTest.driverLabel="$driverLabel"

--- a/test/podmontest/insv.sh
+++ b/test/podmontest/insv.sh
@@ -22,6 +22,7 @@ replicas=1
 deploymentType="statefulset"
 driverLabel="csi-vxflexos"
 podAffinity="false"
+unreachableTolerationSeconds=300
 
 if [ "$DEBUG"x != "x" ]; then
   DEBUG="--dry-run --debug"
@@ -68,6 +69,10 @@ do
           deploymentType="deployment"
           shift
           ;;
+       "--unreachableTolerationSeconds")
+          shift
+          unreachableTolerationSeconds=$1
+          shift
        "--label")
           shift
           driverLabel=$1
@@ -92,6 +97,7 @@ while [ $i -le $instances ]; do
               --set podmonTest.deploymentType=$deploymentType \
               --set podmonTest.replicas=$replicas \
               --set podmonTest.podAffinity=$podAffinity \
+              --set podmonTest.unreachableTolerationSeconds=$unreachableTolerationSeconds \
               --set podmonTest.image="$image" \
               --set podmonTest.zone="$zone" \
               --set podmonTest.driverLabel="$driverLabel"

--- a/test/podmontest/podmontest.go
+++ b/test/podmontest/podmontest.go
@@ -44,7 +44,6 @@ func main() {
 	readExistingEntries(rootDir)
 	for i := 0; ; i++ {
 		makeEntry(string(podTag), rootDir, i)
-		time.Sleep(5 * time.Second)
 	}
 }
 

--- a/test/podmontest/podmontest.go
+++ b/test/podmontest/podmontest.go
@@ -24,6 +24,7 @@ import (
 
 //TAGSIZE standard size for a pod tab
 const TAGSIZE = 16
+
 // InitialPod is the prefix for the initial-pod tag line
 const InitialPod = "initial-pod"
 

--- a/test/podmontest/podmontest.go
+++ b/test/podmontest/podmontest.go
@@ -24,6 +24,7 @@ import (
 
 //TAGSIZE standard size for a pod tab
 const TAGSIZE = 16
+// InitialPod is the prefix for the initial-pod tag line
 const InitialPod = "initial-pod"
 
 var rootDir = "/"

--- a/test/sh/nway.sh
+++ b/test/sh/nway.sh
@@ -109,7 +109,7 @@ maxPods=90
 
 # nodelist returns a list of nodes(
 nodelist() {
-	kubectl get nodes -A | grep -v master  | grep -v NAME | awk '{ print $1 }'
+	kubectl get nodes -A | grep -v mast.r  | grep -v NAME | awk '{ print $1 }'
 }
 
 # get the number of pods on a node $1


### PR DESCRIPTION
# Description
This PR contains ONLY test scalability test changes, including:
1. Changes to the podmontest helm chart to make the toleration seconds for an unreachable taint configurable by insv.sh and insu.sh. This will allow us to change how quickly pods will respond to the kubelet down test scenario (default is 300 seconds or 5 minutes).
2. Changes to podmontest.go to record an initial-pod identifier the first time a file is initialized. This allows us to double check easily that files were not reinitialized as a result of fail-overs.
3. Changes to nway.sh to display any changes to the initial identifiers over the life of the test.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x ] Running the nway test testing scalability.
- [x ] Configuring a change to the toleration seconds for unreachable and observing the behavior on response times to kubelet down scenario.
