### PR TITLE
Occasional failure unmounting Unity volume for raw block devices via iSCSI

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -12,3 +12,5 @@ general:
     - CVE-2022-0778
     # Disputed CVEs
     - CVE-2019-1010022
+    - CVE-2022-26280
+    - CVE-2018-25032

--- a/internal/monitor/features/node.feature
+++ b/internal/monitor/features/node.feature
@@ -59,28 +59,31 @@ Feature: Controller Monitor
     And the last log message contains <errorMsg>
 
     Examples:
-      | driver | nodeName | pods | vols | devs | cleaned | unMountErr | rmDirErr    | taintErr       | k8apiErr              | errorMsg                           |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "none"                | "none"                             |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "GetContainerInfo"    | "none"                             |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "ContainerRunning"    | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "K8sTaint"     | "none"                | "Failed to remove taint against node1 node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "RemoveDir" | "none"         | "none"                | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "RemoveDir" | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"     | "RemoveDir" | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "none"      | "none"         | "none"                | "none"                             |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "none"      | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "none"      | "K8sTaint"     | "none"                | "Failed to remove taint against node1 node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "none"      | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "RemoveDir" | "none"         | "none"                | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "RemoveDir" | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"  | "RemoveDir" | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "none"                | "none"                             |
-      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
-      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "NodeUnstageVolume"   | "Couldn't completely cleanup node" |
-      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "NodeUnpublishNFSShareNotFound" | "none" |
-      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"     | "none"      | "none"         | "NodeUnstageNFSShareNotFound"   | "none" |
+      | driver | nodeName | pods | vols | devs | cleaned | unMountErr    | rmDirErr    | taintErr       | k8apiErr              | errorMsg                           |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "none"                | "none"                             |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "GetContainerInfo"    | "none"                             |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "ContainerRunning"    | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "K8sTaint"     | "none"                | "Failed to remove taint against node1 node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "RemoveDir" | "none"         | "none"                | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "RemoveDir" | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "none"        | "RemoveDir" | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "none"      | "none"         | "none"                | "none"                             |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "none"      | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "none"      | "K8sTaint"     | "none"                | "Failed to remove taint against node1 node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "none"      | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "RemoveDir" | "none"         | "none"                | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "RemoveDir" | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | vxflex | "node1"  | 1    | 1    | 1    | 1       | "Unmount"     | "RemoveDir" | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "none"                | "none"                             |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "NodeUnstageVolume"   | "Couldn't completely cleanup node" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "NodeUnpublishNFSShareNotFound" | "none" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "none"        | "none"      | "none"         | "NodeUnstageNFSShareNotFound"   | "none" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "GetLoopBack" | "none"      | "none"         | "none"                | "Couldn't completely cleanup node" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "DelLoopBack" | "none"      | "none"         | "none"                | "Couldn't completely cleanup node" |
+      | unity  | "node1"  | 1    | 1    | 1    | 1       | "UnMountPath" | "RemoveDir" | "K8sTaint"     | "NodeUnpublishVolume" | "Couldn't completely cleanup node" |
       # Multiple pod tests
       | vxflex | "node1"  | 3    | 2    | 1    | 3       | "none"     | "none"      | "none"         | "none"                | "none"                             |
       | vxflex | "node1"  | 3    | 2    | 1    | 2       | "none"     | "none"      | "none"         | "none"                | "Couldn't completely cleanup node" |

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -391,7 +391,7 @@ func (i *integration) deployPods(protected bool, podsPerNode, numVols, numDevs, 
 		deployScript = "insv.sh"
 	case "unity":
 		deployScript = "insu.sh"
-		cleanUpWait = 120 * time.Second
+		cleanUpWait = 60 * time.Second
 	}
 
 	// Set test namespace prefix is based on the driver type.

--- a/internal/monitor/monitor_steps_test.go
+++ b/internal/monitor/monitor_steps_test.go
@@ -74,6 +74,7 @@ type feature struct {
 	//'none', it will validate if it indeed was a successful message.
 	validateLastMessage bool
 	badWatchObject      bool
+	utilMock            *utils.UtilsMock
 }
 
 func (f *feature) aControllerMonitorUnity() error {
@@ -113,6 +114,10 @@ func (f *feature) aControllerMonitor(driver string) error {
 	RemoveDir = f.mockRemoveDir
 	f.badWatchObject = false
 	f.pod2 = nil
+	f.utilMock = new(utils.UtilsMock)
+	getLoopBackDevice = f.utilMock.GetLoopBackDevice
+	deleteLoopBackDevice = f.utilMock.DeleteLoopBackDevice
+	unMountPath = f.utilMock.Unmount
 	return nil
 }
 
@@ -291,6 +296,12 @@ func (f *feature) iInduceError(induced string) error {
 		f.csiapiMock.InducedErrors.NodeUnpublishNFSShareNotFound = true
 	case "NodeUnstageNFSShareNotFound":
 		f.csiapiMock.InducedErrors.NodeUnstageNFSShareNotFound = true
+	case "GetLoopBack":
+		f.utilMock.InducedErrors.GetLoopBackDevice = true
+	case "DelLoopBack":
+		f.utilMock.InducedErrors.DeleteLoopBackDevice = true
+	case "UnMountPath":
+		f.utilMock.InducedErrors.Unmount = true
 	default:
 		return fmt.Errorf("Unknown induced error: %s", induced)
 	}

--- a/internal/monitor/monitor_steps_test.go
+++ b/internal/monitor/monitor_steps_test.go
@@ -74,7 +74,7 @@ type feature struct {
 	//'none', it will validate if it indeed was a successful message.
 	validateLastMessage bool
 	badWatchObject      bool
-	utilMock            *utils.UtilsMock
+	utilMock            *utils.Mock
 }
 
 func (f *feature) aControllerMonitorUnity() error {
@@ -114,7 +114,7 @@ func (f *feature) aControllerMonitor(driver string) error {
 	RemoveDir = f.mockRemoveDir
 	f.badWatchObject = false
 	f.pod2 = nil
-	f.utilMock = new(utils.UtilsMock)
+	f.utilMock = new(utils.Mock)
 	getLoopBackDevice = f.utilMock.GetLoopBackDevice
 	deleteLoopBackDevice = f.utilMock.DeleteLoopBackDevice
 	unMountPath = f.utilMock.Unmount

--- a/internal/utils/linuxLoopBackDevice.go
+++ b/internal/utils/linuxLoopBackDevice.go
@@ -26,6 +26,7 @@ var (
 	execCommand = exec.Command
 )
 
+// GetLoopBackDevice get the loopbackdevice for given pv
 func GetLoopBackDevice(pvname string) (string, error) {
 	textBytes, err := execCommand("/usr/sbin/losetup", "-a").Output()
 	if err != nil || string(textBytes) == "" {
@@ -43,6 +44,7 @@ func GetLoopBackDevice(pvname string) (string, error) {
 	return loopDevices[0], nil
 }
 
+// DeleteLoopBackDevice deletes the loopbackdevice from the system
 func DeleteLoopBackDevice(loopDev string) ([]byte, error) {
 	cmd := execCommand("/usr/sbin/losetup", "-d", loopDev)
 	return cmd.Output()

--- a/internal/utils/linuxLoopBackDevice.go
+++ b/internal/utils/linuxLoopBackDevice.go
@@ -1,0 +1,49 @@
+//go:build test || linux
+// +build test linux
+
+/*
+ * Copyright (c) 2021. Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package utils
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	execCommand = exec.Command
+)
+
+func GetLoopBackDevice(pvname string) (string, error) {
+	textBytes, err := execCommand("/usr/sbin/losetup", "-a").Output()
+	if err != nil || string(textBytes) == "" {
+		return "", err
+	}
+
+	cmd := execCommand("grep", pvname)
+	cmd.Stdin = bytes.NewBuffer(textBytes)
+	textBytes, err = cmd.Output()
+	if err != nil || string(textBytes) == "" {
+		return "", err
+	}
+	log.Debugf("losetup output: %s", string(textBytes))
+	loopDevices := strings.Split(string(textBytes), ":")
+	return loopDevices[0], nil
+}
+
+func DeleteLoopBackDevice(loopDev string) ([]byte, error) {
+	cmd := execCommand("/usr/sbin/losetup", "-d", loopDev)
+	return cmd.Output()
+}

--- a/internal/utils/mock.go
+++ b/internal/utils/mock.go
@@ -15,8 +15,8 @@ import (
 	"errors"
 )
 
-//UtilsMock is a mock structure used for testing
-type UtilsMock struct {
+//Mock is a mock structure used for testing
+type Mock struct {
 	InducedErrors struct {
 		GetLoopBackDevice    bool
 		DeleteLoopBackDevice bool
@@ -25,16 +25,16 @@ type UtilsMock struct {
 	}
 }
 
-// GetLoopBackDevice gets all the volume attachments in the K8S system
-func (mock *UtilsMock) GetLoopBackDevice(pv string) (string, error) {
+// GetLoopBackDevice gets the loopbackdevice for given pv
+func (mock *Mock) GetLoopBackDevice(pv string) (string, error) {
 	if mock.InducedErrors.GetLoopBackDevice {
 		return "", errors.New("induced GetLoopBackDevice error")
 	}
 	return pv, nil
 }
 
-// DeleteLoopBackDevice deletes a volume attachment by name.
-func (mock *UtilsMock) DeleteLoopBackDevice(device string) ([]byte, error) {
+// DeleteLoopBackDevice deletes a loopbackdevice.
+func (mock *Mock) DeleteLoopBackDevice(device string) ([]byte, error) {
 	delSucc := []byte("loopbackdevice")
 	if mock.InducedErrors.DeleteLoopBackDevice {
 		return nil, errors.New("induced DeleteLoopBackDevice error")
@@ -43,7 +43,7 @@ func (mock *UtilsMock) DeleteLoopBackDevice(device string) ([]byte, error) {
 }
 
 // Unmount is a wrapper around syscall.Unmount
-func (mock *UtilsMock) Unmount(devName string, flags int) error {
+func (mock *Mock) Unmount(devName string, flags int) error {
 	if mock.InducedErrors.Unmount {
 		return errors.New("induced Unmount error")
 	}
@@ -51,7 +51,7 @@ func (mock *UtilsMock) Unmount(devName string, flags int) error {
 }
 
 // Creat is a wrapper around syscall.Creat
-func (mock *UtilsMock) Creat(filepath string, flags int) (int, error) {
+func (mock *Mock) Creat(filepath string, flags int) (int, error) {
 	if mock.InducedErrors.Creat {
 		return 1, errors.New("induced Creat error")
 	}

--- a/internal/utils/mock.go
+++ b/internal/utils/mock.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022. Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package utils
+
+import (
+	"errors"
+)
+
+//UtilsMock is a mock structure used for testing
+type UtilsMock struct {
+	InducedErrors struct {
+		GetLoopBackDevice    bool
+		DeleteLoopBackDevice bool
+		Unmount              bool
+		Creat                bool
+	}
+}
+
+// GetLoopBackDevice gets all the volume attachments in the K8S system
+func (mock *UtilsMock) GetLoopBackDevice(pv string) (string, error) {
+	if mock.InducedErrors.GetLoopBackDevice {
+		return "", errors.New("induced GetLoopBackDevice error")
+	}
+	return pv, nil
+}
+
+// DeleteLoopBackDevice deletes a volume attachment by name.
+func (mock *UtilsMock) DeleteLoopBackDevice(device string) ([]byte, error) {
+	delSucc := []byte("loopbackdevice")
+	if mock.InducedErrors.DeleteLoopBackDevice {
+		return nil, errors.New("induced DeleteLoopBackDevice error")
+	}
+	return delSucc, nil
+}
+
+// Unmount is a wrapper around syscall.Unmount
+func (mock *UtilsMock) Unmount(devName string, flags int) error {
+	if mock.InducedErrors.Unmount {
+		return errors.New("induced Unmount error")
+	}
+	return nil
+}
+
+// Creat is a wrapper around syscall.Creat
+func (mock *UtilsMock) Creat(filepath string, flags int) (int, error) {
+	if mock.InducedErrors.Creat {
+		return 1, errors.New("induced Creat error")
+	}
+	return 0, nil
+}


### PR DESCRIPTION
# Description
Occasional failure unmounting Unity volume for raw block devices via iSCSI.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/237 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run integration Test for more tan 24 hours, and observed that stale loopbackdevice(s) are cleaned up.

time="2022-04-06T18:48:40Z" level=info msg="losetup output: /dev/loop2: [0005]:4601283 (/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/podmonvol-af77815a05/dev/584926b7-4368-4c26-9841-c56ca3b57267)\n"
time="2022-04-06T18:48:40Z" level=info msg="LOOOOOOOOOOOOOOOOPPPPBACK DEVICE: /dev/loop2"
time="2022-04-06T18:48:40Z" level=info msg="sucessfully unmounted block device: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/podmonvol-af77815a05/dev/584926b7-4368-4c26-9841-c56ca3b57267"
time="2022-04-06T18:48:40Z" level=info msg="removed block device: /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/podmonvol-af77815a05/dev/584926b7-4368-4c26-9841-c56ca3b57267"

- [x] Test B
--- PASS: TestNodeMode (1.58s)
=== RUN   TestMapEqualsMap
--- PASS: TestMapEqualsMap (0.00s)
=== RUN   TestPowerFlexShortCheck
time="2022-04-07T12:07:08-04:00" level=info msg="Skipping short integration test. To enable short integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestPowerFlexShortCheck (0.00s)
=== RUN   TestUnityShortCheck
time="2022-04-07T12:07:08-04:00" level=info msg="Skipping short integration test. To enable short integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestUnityShortCheck (0.00s)
=== RUN   TestPowerFlexShortIntegration
time="2022-04-07T12:07:08-04:00" level=info msg="Skipping integration test. To enable integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestPowerFlexShortIntegration (0.00s)
=== RUN   TestUnityShortIntegration
time="2022-04-07T12:07:08-04:00" level=info msg="Skipping integration test. To enable integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestUnityShortIntegration (0.00s)
PASS
coverage: 93.1% of statements
status 0
ok      podmon/internal/monitor 7.923s  coverage: 93.1% of statements
