### PR TITLE
Protect CSI driver node pods to avoid storage workload scheduling

### DIFF
--- a/internal/k8sapi/mock.go
+++ b/internal/k8sapi/mock.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -23,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	"time"
 )
 
 //K8sMock is a mock structure used for testing
@@ -422,10 +423,10 @@ func (mock *K8sMock) TaintNode(ctx context.Context, nodeName, taintKey string, e
 			})
 		}
 		node.Spec.Taints = updatedTaints
+		mock.AddNode(node)
 	} else {
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +50,13 @@ const hostNameTopologyKey = "kubernetes.io/hostname"
 func (cm *PodMonitorType) controllerModePodHandler(pod *v1.Pod, eventType watch.EventType) error {
 	log.Debugf("podMonitorHandler-controller:  name %s/%s node %s message %s reason %s event %v",
 		pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Spec.NodeName, pod.Status.Message, pod.Status.Reason, eventType)
+
+	driverNamespace := os.Getenv("MY_POD_NAMESPACE")
+	log.Infof("podMonitorHandler-controller: driverNamespace %s", driverNamespace)
+	// For driver pod
+	if driverNamespace == pod.ObjectMeta.Namespace {
+		return cm.controllerModeDriverPodHandler(pod, eventType)
+	}
 	// Lock so that only one thread is processing pod at a time
 	podKey := getPodKey(pod)
 	// Clean up pod key to PodInfo and CrashLoopBackOffCount mappings if deleting.
@@ -78,7 +86,7 @@ func (cm *PodMonitorType) controllerModePodHandler(pod *v1.Pod, eventType watch.
 			// Determine if node tainted
 			taintnosched := nodeHasTaint(node, nodeUnreachableTaint, v1.TaintEffectNoSchedule)
 			taintnoexec := nodeHasTaint(node, nodeUnreachableTaint, v1.TaintEffectNoExecute)
-			taintpodmon := nodeHasTaint(node, PodmonTaintKey, v1.TaintEffectNoSchedule)
+			taintpodmon := nodeHasTaint(node, PodmonTaintKey, v1.TaintEffectNoSchedule) || nodeHasTaint(node, PodmonDriverPodTaintKey, v1.TaintEffectNoSchedule)
 
 			// Determine pod status
 			ready := false
@@ -269,7 +277,7 @@ func (cm *PodMonitorType) controllerCleanupPod(pod *v1.Pod, node *v1.Node, reaso
 	}
 
 	// Add a taint for the pod on the node.
-	if err = taintNode(node.ObjectMeta.Name, false); err != nil {
+	if err = taintNode(node.ObjectMeta.Name, PodmonTaintKey, false); err != nil {
 		log.WithFields(fields).Errorf("Failed to update taint against %s node: %v", node.ObjectMeta.Name, err)
 		return false
 	}
@@ -418,7 +426,7 @@ func (cm *PodMonitorType) ArrayConnectivityMonitor() {
 		// Taint all the nodes that were not connected
 		for nodeName := range nodesToTaint {
 			log.Infof("Tainting node %s because of connectivity loss", nodeName)
-			err := taintNode(nodeName, false)
+			err := taintNode(nodeName, PodmonTaintKey, false)
 			if err != nil {
 				log.Errorf("Unable to taint node: %s: %s", nodeName, err.Error())
 			}
@@ -562,12 +570,12 @@ func callK8sAPITaint(operation, nodeName, taintKey string, effect v1.TaintEffect
 }
 
 // taintNode adds or removes the podmon taint against node with 'nodeName'
-func taintNode(nodeName string, removeTaint bool) error {
+func taintNode(nodeName, taintKey string, removeTaint bool) error {
 	operation := "tainting "
 	if removeTaint {
 		operation = "untainting "
 	}
-	return callK8sAPITaint(operation, nodeName, PodmonTaintKey, v1.TaintEffectNoSchedule, removeTaint)
+	return callK8sAPITaint(operation, nodeName, taintKey, v1.TaintEffectNoSchedule, removeTaint)
 }
 
 func nodeHasTaint(node *v1.Node, key string, taintEffect v1.TaintEffect) bool {
@@ -633,4 +641,73 @@ func mapEqualsMap(map1, map2 map[string]string) bool {
 		}
 	}
 	return true
+}
+
+// controllerModeDriverPodHandler handles controller mode functionality when a driver pod event happens
+func (cm *PodMonitorType) controllerModeDriverPodHandler(pod *v1.Pod, eventType watch.EventType) error {
+	log.Debugf("controllerModeDriverPodHandler-controller:  name %s/%s node %s message %s reason %s event %v",
+		pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Spec.NodeName, pod.Status.Message, pod.Status.Reason, eventType)
+
+	// Lock so that only one thread is processing pod at a time
+	podKey := getPodKey(pod)
+	// Clean up pod key to PodInfo and CrashLoopBackOffCount mappings if deleting.
+	if eventType == watch.Deleted {
+		cm.PodKeyToControllerPodInfo.Delete(podKey)
+		cm.PodKeyToCrashLoopBackOffCount.Delete(podKey)
+		return nil
+	}
+	// Single thread processing of this pod
+	Lock(podKey, pod, LockSleepTimeDelay)
+	defer Unlock(podKey)
+	// Check that pod is still present
+	ctx, cancel := K8sAPI.GetContext(MediumTimeout)
+	defer cancel()
+	pod, err := K8sAPI.GetPod(ctx, pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
+	if err != nil {
+		log.Errorf("GetPod failed: %s: %s", podKey, err)
+		return err
+	}
+	if pod.Spec.NodeName != "" {
+		log.Debugf("Getting node %s", pod.Spec.NodeName)
+		node, err := K8sAPI.GetNode(ctx, pod.Spec.NodeName)
+		if err != nil {
+			log.Errorf("GetNode failed: %s: %s", pod.Spec.NodeName, err)
+		} else {
+			// Determine pod status
+			ready := false
+			initialized := true
+			conditions := pod.Status.Conditions
+			for _, condition := range conditions {
+				log.Debugf("pod condition.Type: %s %v", condition.Type, condition.Status)
+				if condition.Type == podReadyCondition {
+					ready = condition.Status == v1.ConditionTrue
+				}
+				if condition.Type == podInitializedCondition {
+					initialized = condition.Status == v1.ConditionTrue
+				}
+			}
+
+			if !ready {
+				log.Infof("Tainting node %s because of driver node pod down", node.ObjectMeta.Name)
+				err := taintNode(node.ObjectMeta.Name, PodmonDriverPodTaintKey, false)
+				if err != nil {
+					log.Errorf("Unable to taint node: %s: %s", node.ObjectMeta.Name, err.Error())
+				}
+			} else {
+				hasTaint := nodeHasTaint(node, PodmonDriverPodTaintKey, v1.TaintEffectNoSchedule)
+				//remove taint
+				if hasTaint {
+					err := taintNode(node.ObjectMeta.Name, PodmonDriverPodTaintKey, true)
+					if err != nil {
+						log.Errorf("Unable to untaint node: %s: %s", node.ObjectMeta.Name, err.Error())
+					}
+				}
+			}
+
+			log.Infof("podMonitorHandler: namespace: %s name: %s nodename: %s initialized: %t ready: %t ",
+				pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Spec.NodeName, initialized, ready)
+		}
+	}
+
+	return nil
 }

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -153,5 +153,5 @@ Feature: Controller Monitor
       | "node1" | "Ready"       | "none"          | "Updated" |
       | "node1" | "NotReady"    | "GetPod"        | "Updated" |
       | "node1" | "NotReady"    | "GetNode"       | "Updated" |
-      
+
  

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -140,16 +140,17 @@ Feature: Controller Monitor
     Given a controller monitor "vxflex"
     And a driver pod for node <podnode> with condition <condition>
     And I induce error <error>
+    And I taint the node <podnode> with <taint>
     When I call controllerModeDriverPodHandler with event <eventtype>
-    And the <podnode> is tainted
+    And the node <podnode> is tainted <tainted>
 
     Examples:
-      | podnode | condition     |  error          | eventtype |
-      | "node1" | "Initialized" | "none"          | "Updated" |
-      | "node1" | "NotReady"    | "none"          | "Updated" |
-      | "node1" | "NotReady"    | "none"          | "Updated" |
-      | "node1" | "CrashLoop"   | "none"          | "Updated" |
-      | "node1" | "NotReady"    | "none"          | "Deleted" |
-      | "node1" | "Ready"       | "none"          | "Updated" |
-      | "node1" | "NotReady"    | "GetPod"        | "Updated" |
-      | "node1" | "NotReady"    | "GetNode"       | "Updated" |
+      | podnode | condition     |  error          | eventtype | tainted | taint   |
+      | "node1" | "Initialized" | "none"          | "Updated" | "false" | "false" |
+      | "node1" | "NotReady"    | "none"          | "Updated" | "true" | "false" |
+      | "node1" | "NotReady"    | "none"          | "Updated" | "true" | "false" |
+      | "node1" | "CrashLoop"   | "none"          | "Updated" | "false" | "false" |
+      | "node1" | "NotReady"    | "none"          | "Deleted" | "true" | "false" |
+      | "node1" | "Ready"       | "none"          | "Updated" | "false" | "true" |
+      | "node1" | "NotReady"    | "GetPod"        | "Updated" | "false" | "false" |
+      | "node1" | "NotReady"    | "GetNode"       | "Updated" | "false" | "false" |

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -153,4 +153,5 @@ Feature: Controller Monitor
       | "node1" | "Ready"       | "none"          | "Updated" |
       | "node1" | "NotReady"    | "GetPod"        | "Updated" |
       | "node1" | "NotReady"    | "GetNode"       | "Updated" |
+      
  

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -153,5 +153,3 @@ Feature: Controller Monitor
       | "node1" | "Ready"       | "none"          | "Updated" |
       | "node1" | "NotReady"    | "GetPod"        | "Updated" |
       | "node1" | "NotReady"    | "GetNode"       | "Updated" |
-
- 

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -37,7 +37,7 @@ Feature: Controller Monitor
     And the last log message contains <errormsg>
 
     Examples:
-      | podnode | nvol | condition     | affin   | nodetaint | error         | eventtype | cleaned | info    | errormsg                                                   |
+      | podnode | nvol | condition     | affin   | nodetaint | error           | eventtype | cleaned | info    | errormsg                                                   |
       | "node1" | 2    | "Initialized" | "false" | "noexec"  | "none"          | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
       | "node1" | 2    | "NotReady"    | "false" | "noexec"  | "none"          | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
       | "node1" | 2    | "NotReady"    | "false" | "nosched" | "none"          | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
@@ -67,7 +67,7 @@ Feature: Controller Monitor
     And the last log message contains <errormsg>
 
     Examples:
-      | podnode | nvol | condition     | affin   | nodetaint | error         | eventtype | cleaned | info    | errormsg                                                   |
+      | podnode | nvol | condition     | affin   | nodetaint | error           | eventtype | cleaned | info    | errormsg                                                   |
       | "node1" | 2    | "NotReady"    | "false" | "nosched" | "NoAnnotation"  | "Updated" | "false" | "false" | "There were 2 errors calling ControllerUnpublishVolume"    |
       | "node1" | 2    | "NotReady"    | "false" | "nosched" | "BadCSINode"    | "Updated" | "false" | "false" | "There were 2 errors calling ControllerUnpublishVolume"    |
 
@@ -86,7 +86,7 @@ Feature: Controller Monitor
     And the last log message contains <errormsg>
 
     Examples:
-      | podnode | nvol | condition     | affin   | nodetaint | error         | eventtype | cleaned | info    | errormsg                                                     |
+      | podnode | nvol | condition     | affin   | nodetaint | error           | eventtype | cleaned | info    | errormsg                                                   |
       | "node1" | 2    | "Initialized" | "false" | "noexec"  | "none"          | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
       | "node1" | 2    | "NotReady"    | "false" | "noexec"  | "none"          | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
       | "node1" | 2    | "NotReady"    | "false" | "nosched" | "none"          | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
@@ -134,3 +134,23 @@ Feature: Controller Monitor
     | "node1" | 2    | "Ready"       | "true"  | "none"    | "none"        | "required"      | "false" |
     | "node1" | 2    | "Ready"       | "true"  | "none"    | "none"        | "labelselector" | "false" |
     | "node1" | 2    | "Ready"       | "true"  | "none"    | "none"        | "operator"      | "false" |
+
+  @controller-mode
+  Scenario Outline: test controllerModeDriverPodHandler
+    Given a controller monitor "vxflex"
+    And a driver pod for node <podnode> with condition <condition>
+    And I induce error <error>
+    When I call controllerModeDriverPodHandler with event <eventtype>
+    And the <podnode> is tainted
+
+    Examples:
+      | podnode | condition     |  error          | eventtype |
+      | "node1" | "Initialized" | "none"          | "Updated" |
+      | "node1" | "NotReady"    | "none"          | "Updated" |
+      | "node1" | "NotReady"    | "none"          | "Updated" |
+      | "node1" | "CrashLoop"   | "none"          | "Updated" |
+      | "node1" | "NotReady"    | "none"          | "Deleted" |
+      | "node1" | "Ready"       | "none"          | "Updated" |
+      | "node1" | "NotReady"    | "GetPod"        | "Updated" |
+      | "node1" | "NotReady"    | "GetNode"       | "Updated" |
+ 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -179,7 +179,6 @@ func podMonitorHandler(eventType watch.EventType, object interface{}) error {
 	pm := &PodMonitor
 	switch PodMonitor.Mode {
 	case "controller":
-		// driver-namespace == pod.spec.namespace call different function.
 		if err := pm.controllerModePodHandler(pod, eventType); err != nil {
 			return err
 		}

--- a/internal/monitor/monitor_steps_test.go
+++ b/internal/monitor/monitor_steps_test.go
@@ -1047,6 +1047,40 @@ func (f *feature) iCallGetPodAffinityLabels() error {
 	return nil
 }
 
+func (f *feature) aControllerMonitorNodePod(arg1 string) error {
+	return godog.ErrPending
+}
+
+func (f *feature) aDriverPodForNodeWithCondition(node, condition string) error {
+	pod := f.createPod(node, 1, condition, "false")
+	f.pod = pod
+	f.k8sapiMock.AddPod(pod)
+	return nil
+}
+
+func (f *feature) iCallControllerModeDriverPodHandlerWithEvent(event string) error {
+	var eventType watch.EventType
+	switch event {
+	case "Added":
+		eventType = watch.Added
+	case "Modified":
+		eventType = watch.Modified
+	case "Deleted":
+		eventType = watch.Deleted
+	default:
+		eventType = watch.Error
+	}
+	f.err = f.podmonMonitor.controllerModeDriverPodHandler(f.pod, eventType)
+	if f.pod2 != nil {
+		f.podmonMonitor.controllerModeDriverPodHandler(f.pod2, eventType)
+	}
+	return nil
+}
+
+func (f *feature) theIsTainted(node string) error {
+	return nil
+}
+
 func MonitorTestScenarioInit(context *godog.ScenarioContext) {
 	f := &feature{}
 	context.Step(`^a controller monitor "([^"]*)"$`, f.aControllerMonitor)
@@ -1085,4 +1119,7 @@ func MonitorTestScenarioInit(context *godog.ScenarioContext) {
 	context.Step(`^a controller pod with podaffinitylabels$`, f.aControllerPodWithPodaffinitylabels)
 	context.Step(`^create a pod for node "([^"]*)" with (\d+) volumes condition "([^"]*)" affinity "([^"]*)" errorcase "([^"]*)"$`, f.createAPodForNodeWithVolumesConditionAffinityErrorcase)
 	context.Step(`^I call getPodAffinityLabels$`, f.iCallGetPodAffinityLabels)
+	context.Step(`^a driver pod for node "([^"]*)" with condition "([^"]*)"$`, f.aDriverPodForNodeWithCondition)
+	context.Step(`^I call controllerModeDriverPodHandler with event "([^"]*)"$`, f.iCallControllerModeDriverPodHandlerWithEvent)
+	context.Step(`^the "([^"]*)" is tainted$`, f.theIsTainted)
 }

--- a/internal/monitor/node.go
+++ b/internal/monitor/node.go
@@ -298,7 +298,6 @@ func (pm *PodMonitorType) nodeModeCleanupPods(node *v1.Node) bool {
 
 		// Check containers to make sure they're not running. This uses the containerInfos map obtained above.
 		pod := podInfo.Pod
-		namespace, name := splitPodKey(podKey)
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 			containerID := containerStatus.ContainerID
 			cid := strings.Split(containerID, "//")
@@ -314,6 +313,7 @@ func (pm *PodMonitorType) nodeModeCleanupPods(node *v1.Node) bool {
 		}
 
 		// Check to make sure the pod has been deleted, or still exists
+		namespace, name := splitPodKey(podKey)
 		currentPod, err := K8sAPI.GetPod(ctx, namespace, name)
 		if err == nil {
 			// We retrieve a pod for the namespace/name... see if same one

--- a/internal/monitor/node.go
+++ b/internal/monitor/node.go
@@ -15,19 +15,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/dell/gofsutil"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/watch"
-	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"os"
 	"podmon/internal/criapi"
 	"podmon/internal/k8sapi"
 	"podmon/internal/utils"
 	"strings"
 	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/dell/gofsutil"
+	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 //APICheckInterval interval to wait before calling node API after successful call
@@ -134,6 +135,12 @@ func (pm *PodMonitorType) nodeModePodHandler(pod *v1.Pod, eventType watch.EventT
 	podKey := getPodKey(pod)
 	// Check that this pod belongs to our node
 	nodeName := os.Getenv("KUBE_NODE_NAME")
+	driverNamespace := os.Getenv("MY_POD_NAMESPACE")
+	if driverNamespace == pod.ObjectMeta.Namespace {
+		//driver pod, no need to protect at node
+		return nil
+	}
+
 	fields := make(map[string]interface{})
 	fields["Namespace"] = pod.ObjectMeta.Namespace
 	fields["PodName"] = pod.ObjectMeta.Name
@@ -291,6 +298,7 @@ func (pm *PodMonitorType) nodeModeCleanupPods(node *v1.Node) bool {
 
 		// Check containers to make sure they're not running. This uses the containerInfos map obtained above.
 		pod := podInfo.Pod
+		namespace, name := splitPodKey(podKey)
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 			containerID := containerStatus.ContainerID
 			cid := strings.Split(containerID, "//")
@@ -306,7 +314,6 @@ func (pm *PodMonitorType) nodeModeCleanupPods(node *v1.Node) bool {
 		}
 
 		// Check to make sure the pod has been deleted, or still exists
-		namespace, name := splitPodKey(podKey)
 		currentPod, err := K8sAPI.GetPod(ctx, namespace, name)
 		if err == nil {
 			// We retrieve a pod for the namespace/name... see if same one
@@ -342,7 +349,11 @@ func (pm *PodMonitorType) nodeModeCleanupPods(node *v1.Node) bool {
 	// Don't remove the taint if we had an error cleaning up a pod, or we skipped a pod because
 	// it was still present. Instead we will do another cleanup cycle.
 	if removeTaint && len(podKeysSkipped) == 0 && len(podKeysWithError) == 0 {
-		if err := taintNode(node.ObjectMeta.Name, true); err != nil {
+		if err := taintNode(node.ObjectMeta.Name, PodmonTaintKey, true); err != nil {
+			log.Errorf("Failed to remove taint against %s node: %v", node.ObjectMeta.Name, err)
+			return false
+		}
+		if err := taintNode(node.ObjectMeta.Name, PodmonDriverPodTaintKey, true); err != nil {
 			log.Errorf("Failed to remove taint against %s node: %v", node.ObjectMeta.Name, err)
 			return false
 		}

--- a/internal/monitor/node.go
+++ b/internal/monitor/node.go
@@ -353,10 +353,6 @@ func (pm *PodMonitorType) nodeModeCleanupPods(node *v1.Node) bool {
 			log.Errorf("Failed to remove taint against %s node: %v", node.ObjectMeta.Name, err)
 			return false
 		}
-		if err := taintNode(node.ObjectMeta.Name, PodmonDriverPodTaintKey, true); err != nil {
-			log.Errorf("Failed to remove taint against %s node: %v", node.ObjectMeta.Name, err)
-			return false
-		}
 		log.Infof("Cleanup of pods complete: %v", podKeys)
 		return true
 	}


### PR DESCRIPTION
# Description
The CSI node driver when not running on a WN (worker node). the CSI controller should check and taint that node so that pods are not scheduled on that node.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/145  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit test added
- [x] Test run integration test

time="2022-05-19T14:00:25-04:00" level=info msg="Node-mode test finished"
--- PASS: TestNodeMode (1.84s)
=== RUN   TestMapEqualsMap
--- PASS: TestMapEqualsMap (0.00s)
=== RUN   TestPowerFlexShortCheck
time="2022-05-19T14:00:25-04:00" level=info msg="Skipping short integration test. To enable short integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestPowerFlexShortCheck (0.00s)
=== RUN   TestUnityShortCheck
time="2022-05-19T14:00:25-04:00" level=info msg="Skipping short integration test. To enable short integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestUnityShortCheck (0.00s)
=== RUN   TestPowerFlexShortIntegration
time="2022-05-19T14:00:25-04:00" level=info msg="Skipping integration test. To enable integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestPowerFlexShortIntegration (0.00s)
=== RUN   TestUnityShortIntegration
time="2022-05-19T14:00:25-04:00" level=info msg="Skipping integration test. To enable integration test: export RESILIENCY_SHORT_INT_TEST=true"
--- PASS: TestUnityShortIntegration (0.00s)
PASS
coverage: 92.9% of statements
status 0
ok      podmon/internal/monitor 8.292s  coverage: 92.9% of statements
