### PR TITLE
add support for --once in monx.sh

### DIFF
--- a/tools/monx.sh
+++ b/tools/monx.sh
@@ -11,6 +11,7 @@
 #
 
 alias k=kubectl
+once=$1
 while true;
 do
 	date
@@ -64,5 +65,6 @@ END {
 	}
 }
 ' | sort
+	if [ "$once" == "--once" ]; then exit 0; fi
 	sleep 5
 done


### PR DESCRIPTION
# Description
Add support for --once so that monx.sh can be run only once

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/262

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
