### PR TITLE
Updated UBI image to 8.6-903.1661794351

### DIFF
--- a/cmd/podmon/Dockerfile
+++ b/cmd/podmon/Dockerfile
@@ -1,13 +1,13 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-902
+FROM registry.access.redhat.com/ubi8/ubi:8.6-903.1661794351
 LABEL vendor="Dell Inc." \
       name="csm-resiliency" \
       summary="Dell Container Storage Modules (CSM) for Resiliency" \
       description="Makes Kubernetes applications, including those that utilize persistent storage, more resilient to various failures" \
       version="2.0.0" \
       license="Apache-2.0"
-RUN microdnf -y install openssl && \
-    microdnf -y install nettle && \
-    microdnf -y install gnutls && \
-    microdnf -y install systemd
+RUN dnf -y install openssl && \
+    dnf -y install nettle && \
+    dnf -y install gnutls && \
+    dnf -y install systemd
 COPY podmon /podmon
 ENTRYPOINT [ "/podmon" ]


### PR DESCRIPTION
# Description
Updated the UBI for resiliency from 8.6-902 to 8.6-903.1661794351

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#350|

# Checklist:

- [✓ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ✓] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

[✓] powerflex-short-integration-test
[✓ ] powerflex-integration-test
