### PR TITLE
Monitor node events for addition-deletion and update pod detail on modify event of pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module podmon
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bramvdbogaerde/go-scp v0.0.0-20201229172121-7a6c0268fa67

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module podmon
 
-go 1.20
+go 1.19
 
 require (
 	github.com/bramvdbogaerde/go-scp v0.0.0-20201229172121-7a6c0268fa67

--- a/internal/k8sapi/mock.go
+++ b/internal/k8sapi/mock.go
@@ -338,6 +338,7 @@ func (mock *K8sMock) GetNode(ctx context.Context, nodeName string) (*v1.Node, er
 	node.ObjectMeta.Name = nodeName
 	node.ObjectMeta.Annotations = make(map[string]string)
 	node.ObjectMeta.Annotations["csi.volume.kubernetes.io/nodeid"] = "{\"csi-vxflexos.dellemc.com\":\"46C8B5F8-74A3-4B2B-B158-EF845654D38C\"}"
+	node.ObjectMeta.UID = "46C8B5F8-74A3-4B2B-B158-EF845654D38C"
 	return node, nil
 }
 

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -141,6 +141,7 @@ func (cm *PodMonitorType) controllerModePodHandler(pod *v1.Pod, eventType watch.
 					ArrayIDs:          arrayIDs,
 					PodAffinityLabels: podAffinityLabels,
 				}
+				log.Debugf("Updating protected pod info podKey %s pvcCount %d arrayIDs %v", podKey, pvcCount, arrayIDs)
 				cm.PodKeyToControllerPodInfo.Store(podKey, podInfo)
 				if ready {
 					// Delete (reset) the CrashLoopBackOff counter since we're running.

--- a/internal/monitor/driver.go
+++ b/internal/monitor/driver.go
@@ -197,17 +197,10 @@ func (d *UnityDriver) FinalCleanup(rawBlock bool, volumeHandle, pvName, podUUID 
 
 		blockDev := fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/%s/dev/%s", pvName, podUUID)
 		err = unMountPath(blockDev, 1)
-		if err != nil {
-			log.Infof("error in unmount block device in FinalCleanup: %s path: %s", err, blockDev)
-		} else {
-			log.Infof("sucessfully unmounted block device: %s", blockDev)
-		}
+		log.Infof("unmount block device in FinalCleanup path: %s error: %s", blockDev, err)
+
 		err = RemoveDev(blockDev)
-		if err != nil {
-			log.Infof("error remove block device FinalCleanup: %s path: %s", err, blockDev)
-		} else {
-			log.Infof("removed block device: %s", blockDev)
-		}
+		log.Infof("remove block device FinalCleanup path: %s error: %s", blockDev, err)
 	}
 	return nil
 }

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -30,6 +30,7 @@ Feature: Controller Monitor
     Given a controller monitor "vxflex"
     And a pod for node <podnode> with <nvol> volumes condition <condition> affinity <affin>
     And a node <podnode> with taint <nodetaint>
+    And I send a node event type "Modify"
     And I induce error <error>
     When I call controllerModePodHandler with event <eventtype>
     Then the pod is cleaned <cleaned>
@@ -60,6 +61,7 @@ Feature: Controller Monitor
     And I induce error "CSIExtensionsNotPresent"
     And a pod for node <podnode> with <nvol> volumes condition <condition> affinity <affin>
     And a node <podnode> with taint <nodetaint>
+    And I send a node event type "Modify"
     And I induce error <error>
     When I call controllerModePodHandler with event <eventtype>
     Then the pod is cleaned <cleaned>
@@ -79,6 +81,7 @@ Feature: Controller Monitor
     And I call controllerModePodHandler with event "Updated"
     And I induce error "PodNotReady"
     And a node <podnode> with taint <nodetaint>
+    And I send a node event type "Modify"
     And I induce error <error>
     When I call controllerModePodHandler with event <eventtype>
     Then the pod is cleaned <cleaned>
@@ -107,6 +110,8 @@ Feature: Controller Monitor
     Given a controller monitor "vxflex"
     And a pod for node <podnode> with <nvol> volumes condition <condition> affinity <affin>
     And I induce error <error>
+    And a node <podnode> with taint "none"
+    And I send a node event type "Modify"
     When I call controllerModePodHandler with event "Updated"
     And I call ArrayConnectivityMonitor
     Then the pod is cleaned <cleaned>

--- a/internal/monitor/features/monitor.feature
+++ b/internal/monitor/features/monitor.feature
@@ -55,6 +55,7 @@ Feature: Monitor generic code
   Scenario Outline: Test Lock/Unlock and getPodKey
     Given a controller monitor "vxflex"
     And a pod for node <podnode> with <nvol> volumes condition ""
+    And I send a node event type "Modify"
     When I call test lock and getPodKey
    # The previous step will fail if there is an error
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -162,8 +162,8 @@ func (pm *PodMonitorType) GetNodeUid(nodeName string) string {
 	if !ok {
 		return ""
 	}
-	uid := any.(types.UID)
-	return string(uid)
+	uid := fmt.Sprintf("%v", any)
+	return uid
 }
 
 func (pm *PodMonitorType) ClearNodeUid(nodeName, oldNodeUid string) bool {
@@ -279,14 +279,14 @@ func nodeMonitorHandler(eventType watch.EventType, object interface{}) error {
 		pm := &PodMonitor
 		switch eventType {
 		case watch.Added:
-			log.Info("Node created: %s %s", node.ObjectMeta.Name, node.ObjectMeta.UID)
+			log.Infof("Node created: %s %s", node.ObjectMeta.Name, node.ObjectMeta.UID)
 			pm.StoreNodeUid(node.ObjectMeta.Name, string(node.ObjectMeta.UID))
 		case watch.Modified:
-			log.Info("Node updated: %s %s", node.ObjectMeta.Name, node.ObjectMeta.UID)
+			log.Infof("Node updated: %s %s", node.ObjectMeta.Name, node.ObjectMeta.UID)
 			pm.StoreNodeUid(node.ObjectMeta.Name, string(node.ObjectMeta.UID))
 		case watch.Deleted:
 			oldUid := string(node.ObjectMeta.UID)
-			log.Info("Node deleted: %s previously %s", node.ObjectMeta.Name, oldUID)
+			log.Infof("Node deleted: %s previously %s", node.ObjectMeta.Name, oldUID)
 			pm.ClearNodeUid(node.ObjectMeta.Name, oldUid)
 		}
 		// Get the CSI annotations for nodeID

--- a/internal/monitor/monitor_steps_test.go
+++ b/internal/monitor/monitor_steps_test.go
@@ -149,6 +149,9 @@ func (f *feature) aPodForNodeWithVolumesCondition(node string, nvolumes int, con
 	pod := f.createPod(node, nvolumes, condition, "false")
 	f.pod = pod
 	f.k8sapiMock.AddPod(pod)
+	node1, _ := f.k8sapiMock.GetNode(context.Background(), node)
+	f.node = node1
+	f.k8sapiMock.AddNode(node1)
 	return nil
 }
 


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Monitor K8s events on node addition, deletion and modify. Update pod detail when a pod is evict from one node to another on modify event.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/765 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Automated unit test
- [ ] Integration testing
