### PR TITLE
Powerscale Resiliency Test Results in XML Format

### DIFF
--- a/internal/monitor/integration_test.go
+++ b/internal/monitor/integration_test.go
@@ -111,7 +111,7 @@ func TestPowerScaleFirstCheck(t *testing.T) {
 	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
 
 	godogOptions := godog.Options{
-		Format:        "pretty,cucumber:powerscale-first-check-cucumber-report.json",
+		Format:        "pretty,junit:powerscale-first-check-junit-report.xml,cucumber:powerscale-first-check-cucumber-report.json",
 		Paths:         []string{"features"},
 		Tags:          "powerscale-int-setup-check",
 		StopOnFailure: stopOnFailure,
@@ -259,7 +259,7 @@ func TestPowerScaleIntegration(t *testing.T) {
 
 	log.Printf("Starting integration test")
 	godogOptions := godog.Options{
-		Format:        "pretty,cucumber:powerscale-integration-cucumber-report.json",
+		Format:        "pretty,junit:powerscale-integration-junit-report.xml,cucumber:powerscale-integration-cucumber-report.json",
 		Paths:         []string{"features"},
 		Tags:          "powerscale-integration",
 		StopOnFailure: stopOnFailure,

--- a/internal/monitor/short_integration_test.go
+++ b/internal/monitor/short_integration_test.go
@@ -105,7 +105,7 @@ func TestPowerScaleShortCheck(t *testing.T) {
 	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
 
 	godogOptions := godog.Options{
-		Format:        "pretty,cucumber:powerscale-short-check-cucumber-report.json",
+		Format:        "pretty,junit:powerscale-short-check-junit-report.xml,cucumber:powerscale-short-check-cucumber-report.json",
 		Paths:         []string{"features"},
 		Tags:          "powerscale-int-setup-check",
 		StopOnFailure: stopOnFailure,
@@ -253,7 +253,7 @@ func TestPowerScaleShortIntegration(t *testing.T) {
 
 	log.Printf("Starting integration test")
 	godogOptions := godog.Options{
-		Format:        "pretty,cucumber:powerscale-short-integration-cucumber-report.json",
+		Format:        "pretty,junit:powerscale-short-integration-junit-report.xml,cucumber:powerscale-short-integration-cucumber-report.json",
 		Paths:         []string{"features"},
 		Tags:          "powerscale-short-integration",
 		StopOnFailure: stopOnFailure,


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
PowerScale Resiliency integration  output test results in XML format

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/859|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

```
 Examples:
      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
      | ""         | "1-1"       | "1-1" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |

1 scenarios (1 passed)
10 steps (10 passed)
5m36.589770697s
INFO[0346] Integration test finished
--- PASS: TestPowerScaleShortIntegration (336.62s)
PASS
status 0
ok      podmon/internal/monitor 346.809s
[root@master-1-qYJjYHZNjPMbx monitor]# ls
controller.go              integration_test.go    monitor_test.go                              powerscale-short-check-junit-report.xml
driver.go                  Makefile               monitor_test_helpers.go                      powerscale-short-integration-cucumber-report.json
features                   monitor.go             node.go                                      run.integration
integration_steps_test.go  monitor_steps_test.go  powerscale-short-check-cucumber-report.json  short_integration_test.go
[root@master-1-qYJjYHZNjPMbx monitor]# cat cat tpowerscale-short-check-ju^Crt-check-junit-report.xml
[root@master-1-qYJjYHZNjPMbx monitor]# cat powerscale-short-check-junit-report.xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="integration" tests="1" skipped="0" failures="0" errors="0" time="336.589784888">
  <testsuite name="Integration Test" tests="1" skipped="0" failures="0" errors="0" time="336.588488898">
    <testcase name="Basic node failover testing using test StatefulSet pods (node interface down)" status="passed" time="336.588488898"></testcase>
  </testsuite>
```
