### PR TITLE
Updating gofsutil version with latest release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/container-storage-interface/spec v1.7.0
 	github.com/cucumber/godog v0.12.6
 	github.com/dell/dell-csi-extensions/podmon v1.2.0
-	github.com/dell/gofsutil v1.13.0
+	github.com/dell/gofsutil v1.13.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/golang/mock v1.6.0
 	github.com/kubernetes-csi/csi-lib-utils v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/dell/dell-csi-extensions/podmon v1.2.0 h1:bYoTPMz/ILl8+cjK+zkwqX5FfiO
 github.com/dell/dell-csi-extensions/podmon v1.2.0/go.mod h1:MXkd5u3Vt876LEqDeqywlK0Re/IA0FZlHKFWvvdhyzI=
 github.com/dell/gofsutil v1.13.0 h1:kAW+3YbO02GMPJTRy5H9hSsYYq4kip9gCAIffMFFOX4=
 github.com/dell/gofsutil v1.13.0/go.mod h1:UPRuS1blrPnfT2K3nWRrLHIosZsBznDglovA6DRMmUI=
+github.com/dell/gofsutil v1.13.1 h1:hu26rfykH0gvpSxPe5lTBVCHZA3m896/iO+2Ekz0U7A=
+github.com/dell/gofsutil v1.13.1/go.mod h1:UPRuS1blrPnfT2K3nWRrLHIosZsBznDglovA6DRMmUI=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/emicklei/go-restful/v3 v3.10.0 h1:X4gma4HM7hFm6WMeAsTfqA0GOfdNoCzBIkHGoRLGXuM=
 github.com/emicklei/go-restful/v3 v3.10.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/dell-csi-extensions/podmon v1.2.0 h1:bYoTPMz/ILl8+cjK+zkwqX5FfiOB8H4Qa2C17sKzsV4=
 github.com/dell/dell-csi-extensions/podmon v1.2.0/go.mod h1:MXkd5u3Vt876LEqDeqywlK0Re/IA0FZlHKFWvvdhyzI=
-github.com/dell/gofsutil v1.13.0 h1:kAW+3YbO02GMPJTRy5H9hSsYYq4kip9gCAIffMFFOX4=
-github.com/dell/gofsutil v1.13.0/go.mod h1:UPRuS1blrPnfT2K3nWRrLHIosZsBznDglovA6DRMmUI=
 github.com/dell/gofsutil v1.13.1 h1:hu26rfykH0gvpSxPe5lTBVCHZA3m896/iO+2Ekz0U7A=
 github.com/dell/gofsutil v1.13.1/go.mod h1:UPRuS1blrPnfT2K3nWRrLHIosZsBznDglovA6DRMmUI=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Updating karavi-resiliency gofsutil with the new release

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

Short integration test for powerflex

6 scenarios ([32m6 passed[0m)
60 steps ([32m60 passed[0m)
43m49.091590327s
time="2023-09-19T16:11:57-04:00" level=info msg="Integration test finished"
--- PASS: TestPowerFlexShortIntegration (2629.14s)
PASS
status 0
ok  	podmon/internal/monitor	2637.745s
