### PR TITLE
Change ubi micro version to avoid vulnerability

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
          cd cmd/podmon
          chmod +x ../../scripts/buildubimicro.sh
-         buildah unshare ../../scripts/buildubimicro.sh "registry.access.redhat.com/ubi9-micro:9.2-9"
+         buildah unshare ../../scripts/buildubimicro.sh "registry.access.redhat.com/ubi9-micro:9.2"
          make clean build
          podman build -t docker.io/podmon . --build-arg BASEIMAGE="localhost/resiliency-ubimicro"
          podman save docker.io/library/podmon -o /tmp/podmon.tar

--- a/cmd/podmon/Makefile
+++ b/cmd/podmon/Makefile
@@ -26,7 +26,7 @@ build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -a -ldflags '-w' ./...
 
 build-base-image:
-	sh ../../scripts/buildubimicro.sh "registry.access.redhat.com/ubi9-micro:9.2-9"
+	sh ../../scripts/buildubimicro.sh "registry.access.redhat.com/ubi9-micro:9.2"
 
 podman:
 	podman build --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg BASEIMAGE=$(BASEIMAGE) --label commit=$(shell git log --max-count 1 --format="%H") .


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Change the ubi-micro image version to 9.2 to always use the latest changes of 9.2 -- avoid minor patch updates. This change will remove CVE-2023-4911 observed in image scan.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/843 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Tested with automation in Jenkins.
