### PR TITLE
Implement docker multi stage build and use common Go image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout dell-csi-extensions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'dell/dell-csi-extensions'
           path: dell-csi-extensions
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run the forbidden words scan
         uses: dell/common-github-actions/code-sanitizer@main
         with:
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout dell-csi-extensions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'dell/dell-csi-extensions'
           path: dell-csi-extensions
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Go Security
         uses: securego/gosec@master
         with:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run malware scan
         uses: dell/common-github-actions/malware-scanner@main
         with:
@@ -73,15 +73,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.21+
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ^1.21
           cache: false
         id: go
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout dell-csi-extensions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'dell/dell-csi-extensions'
           path: dell-csi-extensions
@@ -93,10 +93,9 @@ jobs:
         run: go mod tidy
       - name: Build podmon Docker Image
         run: |
-         cd cmd/podmon
-         chmod +x ../../scripts/buildubimicro.sh
-         make clean build-base-image build
-         podman build -t docker.io/podmon . --build-arg BASEIMAGE="localhost/resiliency-ubimicro"
+         chmod +x ./scripts/buildubimicro.sh
+         make build-base-image
+         podman build -t docker.io/podmon -f ./Dockerfile --build-arg GOIMAGE=golang:1.21 --build-arg BASEIMAGE="localhost/resiliency-ubimicro"
          podman save docker.io/library/podmon -o /tmp/podmon.tar
          docker load -i /tmp/podmon.tar
       - name: Image scanner
@@ -106,4 +105,3 @@ jobs:
           severity-threshold: HIGH
         env:
           DOCKLE_HOST: "unix:///var/run/docker.sock"
-          

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -14,17 +14,17 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           cache: false
       - name: Checkout the code
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v4
       - name: Vendor packages
         run: |
           go mod vendor
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.53
+          version: latest
           skip-cache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+ARG GOIMAGE
 ARG BASEIMAGE
 
 # Build the module binary
-FROM golang:1.21 as builder
+FROM $GOIMAGE as builder
 
 WORKDIR /workspace
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,14 @@ clean:
 	go clean ./...
 
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -a -ldflags '-w' ./...
+	GOOS=linux CGO_ENABLED=0 go build -o podmon ./cmd/podmon/
 
 build-base-image: download-csm-common
 	$(eval include csm-common.mk)
 	sh ./scripts/buildubimicro.sh $(DEFAULT_BASEIMAGE)
 
 podman: build-base-image
-	podman build --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) -f ./cmd/podmon/Dockerfile --label commit=$(shell git log --max-count 1 --format="%H") .
+	podman build --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) -f ./Dockerfile --label commit=$(shell git log --max-count 1 --format="%H") .
 
 push:
 	podman push "$(REGISTRY):$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 -->
 
 # Dell Container Storage Modules (CSM) for Resiliency
+
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](https://github.com/dell/csm/blob/main/docs/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Podmam Pulls](https://img.shields.io/docker/pulls/dellemc/podmon)](https://hub.docker.com/r/dellemc/podmon)
@@ -45,30 +46,31 @@ For documentation, please visit [Container Storage Modules documentation](https:
 
 If you wish to clone and build CSM for Resiliency, a Linux host is required with the following installed:
 
-| Component       | Version   | Additional Information                                                                                                                     |
-| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Podman          | v4.4.1+   | [Podman installation](https://podman.io/docs/installation)                                                                                                    |
+| Component       | Version   | Additional Information                                                 |
+| --------------- | --------- | ---------------------------------------------------------------------- |
+| Podman          | v4.4.1+   | [Podman installation](https://podman.io/docs/installation)             |
 | Buildah         | v1.29.1+  | [Buildah installation](https://www.redhat.com/sysadmin/getting-started-buildah)                                                                               |
-| Golang          | v1.18+    | [Golang installation](https://github.com/travis-ci/gimme)                                                                                                     |
-| git             | latest    | [Git installation](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)                                                                             |
+| Golang          | v1.21+    | [Golang installation](https://go.dev/dl/)                              |
+| git             | latest    | [Git installation](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)                                                                        |
 
 Once all prerequisites are on the Linux host, follow the steps below to clone, build and deploy CSM for Resiliency:
 
 1. Clone the repository: `git clone https://github.com/dell/karavi-resiliency.git`
 2. Define and export the following environment variables to point to your Podman registry:
 
-    ```
+    ```sh
     export REGISTRY_HOST=<registry host>
     export REGISTRY_PORT=<registry port>
     export VERSION=<version>
     ```
+
 3. At the root of the source tree, run the following to build and deploy: `make`
 
 ## Testing CSM for Resiliency
 
 From the root directory where the repo was cloned, the unit tests can be executed as follows:
 
-```
+```sh
 make unit-test
 ```
 

--- a/cmd/podmon/Dockerfile
+++ b/cmd/podmon/Dockerfile
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG BASEIMAGE
+
+# Build the module binary
+FROM golang:1.21 as builder
+
+WORKDIR /workspace
+COPY . .
+
+# Build the binary
+RUN GOOS=linux CGO_ENABLED=0 go build -o podmon ./cmd/podmon/
+
+# Stage to build the module image
 FROM $BASEIMAGE AS final
 LABEL vendor="Dell Inc." \
       name="csm-resiliency" \
@@ -19,5 +30,7 @@ LABEL vendor="Dell Inc." \
       description="Makes Kubernetes applications, including those that utilize persistent storage, more resilient to various failures" \
       version="2.0.0" \
       license="Apache-2.0"
-COPY podmon /podmon
+
+COPY --from=builder /workspace/podmon /
+
 ENTRYPOINT [ "/podmon" ]

--- a/cmd/podmon/Makefile
+++ b/cmd/podmon/Makefile
@@ -13,7 +13,6 @@
 # limitations under the License.
 # Includes the following generated file to get semantic version information
 
-
 unit-test:
 	go test -race -v -coverprofile=c.out ./...
 

--- a/cmd/podmon/Makefile
+++ b/cmd/podmon/Makefile
@@ -12,28 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Includes the following generated file to get semantic version information
-MAJOR=0
-MINOR=0
-PATCH=54
-VERSION?="v$(MAJOR).$(MINOR).$(PATCH)"
-REGISTRY?="${REGISTRY_HOST}:${REGISTRY_PORT}/podmon"
-BASEIMAGE?="resiliency-ubimicro:latest"
 
-clean:
-	go clean ./...
-
-build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -a -ldflags '-w' ./...
-
-build-base-image: download-csm-common
-	$(eval include csm-common.mk)
-	sh ../../scripts/buildubimicro.sh $(DEFAULT_BASEIMAGE)
-
-podman:
-	podman build --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg BASEIMAGE=$(BASEIMAGE) --label commit=$(shell git log --max-count 1 --format="%H") .
-
-push:
-	podman push "$(REGISTRY):$(VERSION)"
 
 unit-test:
 	go test -race -v -coverprofile=c.out ./...
@@ -41,6 +20,3 @@ unit-test:
 godog:
 	go clean -cache
 	go test -v -coverprofile=c.out -test.run TestMain ./...
-
-download-csm-common:
-	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Implement docker multi stage build to build module and use common Go image for building module.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1098 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran sanity test
 
![Screenshot 2024-02-20 202454](https://github.com/dell/karavi-resiliency/assets/36687396/d9995e98-9213-478f-a459-d83801b74c64)

- [x] Build module image 
![Screenshot 2024-02-20 202515](https://github.com/dell/karavi-resiliency/assets/36687396/4597c084-687f-42a7-81c9-0aa33faa3332)


