### PR TITLE
Add error log and abort pod cleanup k8s event in controllerCleanupPod

### DIFF
--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -263,7 +263,7 @@ func (cm *PodMonitorType) controllerCleanupPod(pod *v1.Pod, node *v1.Node, reaso
 				log.WithFields(fields).Info("SkipArrayConnectionValidation is set and taintnoexec is true- proceeding")
 			} else {
 				if err != nil {
-					log.WithFields(fields).Error("Aborting pod cleanup due to error: %s", err.Error())
+					log.WithFields(fields).Error("Aborting pod cleanup due to error: ", err.Error())
 					if strings.Contains(err.Error(), "Could not determine CSI NodeID for node") {
 						if err = K8sAPI.CreateEvent(podmon, pod, k8sapi.EventTypeWarning, reason,
 							"podmon aborted pod cleanup %s due to missing CSI annotations",

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -263,7 +263,7 @@ func (cm *PodMonitorType) controllerCleanupPod(pod *v1.Pod, node *v1.Node, reaso
 				log.WithFields(fields).Info("SkipArrayConnectionValidation is set and taintnoexec is true- proceeding")
 			} else {
 				if err != nil {
-					log.WithFields(fields).Error("Aborting pod cleanup due to error: ", err.Error())
+					log.WithFields(fields).Info("Aborting pod cleanup due to error: ", err.Error())
 					if strings.Contains(err.Error(), "Could not determine CSI NodeID for node") {
 						if err = K8sAPI.CreateEvent(podmon, pod, k8sapi.EventTypeWarning, reason,
 							"podmon aborted pod cleanup %s due to missing CSI annotations",

--- a/internal/monitor/features/controller.feature
+++ b/internal/monitor/features/controller.feature
@@ -22,7 +22,7 @@ Feature: Controller Monitor
       | "node1" | 2    | "DeleteVolumeAttachment"         | "node1" | "false"   | "Couldn't delete VolumeAttachment"                   |
       | "node1" | 2    | "DeletePod"                      | "node1" | "false"   | "Delete pod failed"                                  |
       | "node1" | 2    | "ControllerUnpublishVolume"      | "node1" | "false"   | "errors calling ControllerUnpublishVolume to fence"  |
-      | "node1" | 2    | "ValidateVolumeHostConnectivity" | "node1" | "false"   | "Aborting pod cleanup because array still connected" |
+      | "node1" | 2    | "ValidateVolumeHostConnectivity" | "node1" | "false"   | "Aborting pod cleanup due to error"                  |
       | "node1" | 2    | "CreateEvent"                    | "node1" | "true"    | "Successfully cleaned up pod"                        |
 
   @controller-mode
@@ -52,8 +52,8 @@ Feature: Controller Monitor
       | "node1" | 2    | "NotReady"    | "false" | "noexec"  | "CreateEvent"   | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
       | "node1" | 2    | "CrashLoop"   | "false" | "noexec"  | "CreateEvent"   | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
       | "node1" | 2    | "Initialized" | "false" | "noexec"  | "CreateEvent"   | "Updated" | "true"  | "false" | "Successfully cleaned up pod"                              |
-      | "node1" | 2    | "NotReady"    | "false" | "nosched" | "NoAnnotation"  | "Updated" | "false"  | "false" | "Aborting pod cleanup because array still connected"      |
-      | "node1" | 2    | "NotReady"    | "false" | "nosched" | "BadCSINode"    | "Updated" | "false"  | "false" | "Aborting pod cleanup because array still connected"      |
+      | "node1" | 2    | "NotReady"    | "false" | "nosched" | "NoAnnotation"  | "Updated" | "false"  | "false" | "Aborting pod cleanup due to error"                       |
+      | "node1" | 2    | "NotReady"    | "false" | "nosched" | "BadCSINode"    | "Updated" | "false"  | "false" | "Aborting pod cleanup due to error"                       |
 
   @controller-mode
   Scenario Outline: test controllerModePodHandler skipping validate volume with a CSIExtensionNotPresent error


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Add error log and abort pod cleanup k8s event for missing CSI Annotations and volume host connectivity validation failure.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1216 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make unit-test
![image](https://github.com/dell/karavi-resiliency/assets/109594002/05614b76-4cab-40e5-8a9d-dc9a428621b4)

- [x] Installed driver with resiliency enabled, created a pod being watched by podmon. Removed the annotations on the node where pod is running, podmon aborted pod cleanup containing the newly added error log and k8s event is created.
![image](https://github.com/dell/karavi-resiliency/assets/109594002/704a3c7a-c658-4a4b-8517-98ed82437e0d)
![image](https://github.com/dell/karavi-resiliency/assets/109594002/84dd0f8b-79c6-4005-9232-fbace80c7eb0)
