### PR TITLE
Updated gofsutil dependency to the latest version 1.16.1.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/container-storage-interface/spec v1.7.0
 	github.com/cucumber/godog v0.12.6
 	github.com/dell/dell-csi-extensions/podmon v1.5.0
-	github.com/dell/gofsutil v1.16.0
+	github.com/dell/gofsutil v1.16.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/golang/mock v1.6.0
 	github.com/kubernetes-csi/csi-lib-utils v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/dell-csi-extensions/podmon v1.5.0 h1:sUzNRc6iUn8QBMb3eUT3h1pYq2hFc6BuatC0SxH1rko=
 github.com/dell/dell-csi-extensions/podmon v1.5.0/go.mod h1:sShMyj45zxiHHfihS3p+oc/U5+EoL+XlM3g9y7zCOls=
-github.com/dell/gofsutil v1.16.0 h1:SjT8/zl+3fTPbTT432Y0H/vEhjbkK14PlqdapRPLKTo=
-github.com/dell/gofsutil v1.16.0/go.mod h1:bZ43qAOqKzGJxCRvkTVD7GCFMNkK37ur84mmMuxQshE=
+github.com/dell/gofsutil v1.16.1 h1:BzdxMdIDgKzinlYyi5G3pi27Jw0cmtqRHM5UsIkoE+w=
+github.com/dell/gofsutil v1.16.1/go.mod h1:bZ43qAOqKzGJxCRvkTVD7GCFMNkK37ur84mmMuxQshE=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/emicklei/go-restful/v3 v3.10.0 h1:X4gma4HM7hFm6WMeAsTfqA0GOfdNoCzBIkHGoRLGXuM=
 github.com/emicklei/go-restful/v3 v3.10.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Updated gofsutil dependency to the latest version 1.16.1.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1221 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit-tests

```
babija-dev:~/csm # git clone -b usr/babija/gofsutil-update https://github.com/dell/karavi-resiliency.git
Cloning into 'karavi-resiliency'...
remote: Enumerating objects: 1862, done.
remote: Counting objects: 100% (1084/1084), done.
remote: Compressing objects: 100% (591/591), done.
remote: Total 1862 (delta 764), reused 632 (delta 474), pack-reused 778
Receiving objects: 100% (1862/1862), 1.81 MiB | 7.96 MiB/s, done.
Resolving deltas: 100% (1120/1120), done.
babija-dev:~/csm # cd karavi-resiliency/
babija-dev:~/csm/karavi-resiliency #
babija-dev:~/csm/karavi-resiliency #
babija-dev:~/csm/karavi-resiliency # go version
go version go1.22.5 linux/amd64
babija-dev:~/csm/karavi-resiliency #
babija-dev:~/csm/karavi-resiliency #
babija-dev:~/csm/karavi-resiliency # go test ./...
go: downloading k8s.io/apimachinery v0.26.2
go: downloading k8s.io/api v0.26.2
go: downloading k8s.io/client-go v0.26.2
go: downloading github.com/container-storage-interface/spec v1.7.0
go: downloading github.com/dell/dell-csi-extensions/podmon v1.5.0
go: downloading github.com/dell/gofsutil v1.16.1
go: downloading k8s.io/cri-api v0.21.6
go: downloading google.golang.org/grpc v1.65.0
go: downloading github.com/cucumber/godog v0.12.6
go: downloading github.com/bramvdbogaerde/go-scp v0.0.0-20201229172121-7a6c0268fa67
go: downloading github.com/golang/mock v1.6.0
go: downloading github.com/kubernetes-csi/csi-lib-utils v0.13.0
go: downloading github.com/spf13/viper v1.15.0
go: downloading k8s.io/klog/v2 v2.80.1
go: downloading k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280
go: downloading k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
go: downloading github.com/imdario/mergo v0.3.6
go: downloading google.golang.org/protobuf v1.34.2
go: downloading github.com/cucumber/messages-go/v16 v16.0.1
go: downloading github.com/spf13/afero v1.9.3
go: downloading github.com/spf13/cast v1.5.0
go: downloading github.com/spf13/jwalterweatherman v1.1.0
go: downloading golang.org/x/time v0.1.0
go: downloading golang.org/x/oauth2 v0.20.0
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157
go: downloading github.com/cucumber/gherkin-go/v19 v19.0.3
go: downloading github.com/hashicorp/go-memdb v1.3.2
go: downloading github.com/gofrs/uuid v4.2.0+incompatible
go: downloading github.com/subosito/gotenv v1.4.2
go: downloading github.com/pelletier/go-toml/v2 v2.0.6
go: downloading github.com/hashicorp/go-immutable-radix v1.3.1
go: downloading github.com/go-openapi/jsonreference v0.20.1
go: downloading github.com/hashicorp/golang-lru v0.5.4
?       podmon/internal/criapi  [no test files]
?       podmon/internal/csiapi  [no test files]
?       podmon/internal/k8sapi  [no test files]
ok      podmon/cmd/podmon       0.460s
?       podmon/internal/utils   [no test files]
?       podmon/test/podmontest  [no test files]
?       podmon/test/ssh/cli     [no test files]
?       podmon/test/ssh/mocks   [no test files]
ok      podmon/internal/monitor 8.808s
ok      podmon/test/ssh 3.557s
babija-dev:~/csm/karavi-resiliency #

```
