### PR TITLE
karavi-resiliency/Add Makefile Targets for Local PR Checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,19 @@ push:
 download-csm-common:
 	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk
 
-.PHONY: actions
-actions: ## Run all the github action checks that run on a pull_request creation
-	act -l | grep -v ^Stage | grep pull_request | grep -v image_security_scan | awk '{print $$2}' | while read WF; do act pull_request --no-cache-server --platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest --job "$${WF}"; done
+.PHONY: actions action-help
+actions: ## Run all GitHub Action checks that run on a pull request creation
+	@echo "Running all GitHub Action checks for pull request events..."
+	@act -l | grep -v ^Stage | grep pull_request | grep -v image_security_scan | awk '{print $$2}' | while read WF; do \
+		echo "Running workflow: $${WF}"; \
+		act pull_request --no-cache-server --platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest --job "$${WF}"; \
+	done
 
-.PHONY: check
-check: ## Echo instructions to run one specific workflow locally
+action-help: ## Echo instructions to run one specific workflow locally
 	@echo "GitHub Workflows can be run locally with the following command:"
 	@echo "act pull_request --no-cache-server --platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest --job <jobid>"
-	@echo
+	@echo ""
 	@echo "Where '<jobid>' is a Job ID returned by the command:"
 	@echo "act -l"
-	@echo
-	@echo "NOTE: if act if not installed, it can be from https://github.com/nektos/act"
+	@echo ""
+	@echo "NOTE: if act is not installed, it can be downloaded from https://github.com/nektos/act"


### PR DESCRIPTION
# Description
This PR adds Makefile targets to run GitHub Actions checks locally:

`actions` Target :
Runs all pull request checks with enhanced logging.
`action-help` Target :
Displays instructions for running specific workflows with act.
Usage:

Run all PR checks: `make actions`
Get workflow instructions: `make action-help`
Enhances local testing and debugging of GitHub Actions.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1490|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested locally using command: `make actions`
![image](https://github.com/user-attachments/assets/e5ade860-fc28-487f-91b5-8e7d14dfba92)
