### PR TITLE
Ensure image version consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2021-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,10 @@ clean:
 build:
 	GOOS=linux CGO_ENABLED=0 go build -o podmon ./cmd/podmon/
 
-podman:
+podman: download-csm-common
+	$(eval include csm-common.mk)
 	go run core/semver/semver.go -f mk >semver.mk
-	make -f docker.mk podman
+	make -f docker.mk podman DEFAULT_GOIMAGE=$(DEFAULT_GOIMAGE) CSM_BASEIMAGE=$(CSM_BASEIMAGE)
 
 push:
 	make -f docker.mk push

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,6 @@
 # limitations under the License.
 # Includes the following generated file to get semantic version information
 
-MAJOR=1
-MINOR=12
-PATCH=0
-VERSION?="v$(MAJOR).$(MINOR).$(PATCH)"
-REGISTRY?="${REGISTRY_HOST}:${REGISTRY_PORT}/podmon"
-
 all: clean podman push
 
 unit-test:
@@ -30,12 +24,12 @@ clean:
 build:
 	GOOS=linux CGO_ENABLED=0 go build -o podmon ./cmd/podmon/
 
-podman: download-csm-common
-	$(eval include csm-common.mk)
-	podman build --pull --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) --build-arg BASEIMAGE=$(CSM_BASEIMAGE) -f ./Dockerfile --label commit=$(shell git log --max-count 1 --format="%H") .
+podman:
+	go run core/semver/semver.go -f mk >semver.mk
+	make -f docker.mk podman
 
 push:
-	podman push "$(REGISTRY):$(VERSION)"
+	make -f docker.mk push
 
 download-csm-common:
 	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,0 +1,1 @@
+core_generated.go

--- a/core/core.go
+++ b/core/core.go
@@ -1,0 +1,34 @@
+//  Copyright © 2021 - 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//go:generate go run semver/semver.go -f semver.tpl -o core_generated.go
+
+package core
+
+import "time"
+
+var (
+	// SemVer is the semantic version.
+	SemVer = "unknown"
+
+	// CommitSha7 is the short version of the commit hash from which
+	// this program was built.
+	CommitSha7 string
+
+	// CommitSha32 is the long version of the commit hash from which
+	// this program was built.
+	CommitSha32 string
+
+	// CommitTime is the commit timestamp of the commit from which
+	// this program was built.
+	CommitTime time.Time
+)

--- a/core/core.go
+++ b/core/core.go
@@ -1,4 +1,4 @@
-//  Copyright © 2021 - 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2021 - 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/core/core.go
+++ b/core/core.go
@@ -1,4 +1,4 @@
-//  Copyright © 2021 - 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+//  Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/core/semver.tpl
+++ b/core/semver.tpl
@@ -1,0 +1,11 @@
+package core
+
+import "time"
+
+func init() {
+	SemVer = "{{.SemVer}}"
+	CommitSha7 = "{{.Sha7}}"
+	CommitSha32 = "{{.Sha32}}"
+	CommitTime = time.Unix({{.Epoch}}, 0)
+}
+

--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -32,30 +32,46 @@ import (
 	"time"
 )
 
-func main() {
-	var (
-		tpl    *template.Template
-		format string
-		output string
-		export bool
-	)
+var (
+	format string
+	output string
+	export bool
+	tpl    *template.Template
+)
 
-	flag.StringVar(
-		&format,
-		"f",
-		"ver",
-		"The output format: env, go, json, mk, rpm, ver")
-	flag.StringVar(
-		&output,
-		"o",
-		"",
-		"The output file")
-	flag.BoolVar(
-		&export,
-		"x",
-		false,
-		"Export env vars. Used with -f env")
+func init() {
+	if flag.Lookup("f") == nil {
+		flag.StringVar(
+			&format,
+			"f",
+			"ver",
+			"The output format: env, go, json, mk, rpm, ver")
+	}
+	if flag.Lookup("o") == nil {
+		flag.StringVar(
+			&output,
+			"o",
+			"",
+			"The output file")
+	}
+	if flag.Lookup("x") == nil {
+		flag.BoolVar(
+			&export,
+			"x",
+			false,
+			"Export env vars. Used with -f env")
+	}
+}
+
+func initFlags() {
+	format = flag.Lookup("f").Value.(flag.Getter).Get().(string)
+	output = flag.Lookup("o").Value.(flag.Getter).Get().(string)
+	export = flag.Lookup("x").Value.(flag.Getter).Get().(bool)
+}
+
+func main() {
 	flag.Parse()
+	initFlags()
 
 	if strings.EqualFold("env", format) {
 		format = "env"
@@ -71,10 +87,9 @@ func main() {
 		format = "ver"
 	} else {
 		if fileExists(format) {
-			buf, err := os.ReadFile(format) // #nosec G304
+			buf, err := ReadFile(format) // #nosec G304
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error: read tpl failed: %v\n", err)
-				os.Exit(1)
+				errorExit(fmt.Sprintf("error: read tpl failed: %v\n", err))
 			}
 			format = string(buf)
 		}
@@ -86,8 +101,7 @@ func main() {
 	if len(output) > 0 {
 		fout, err := os.Create(filepath.Clean(output))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
+			errorExit(fmt.Sprintf("error: %v\n", err))
 		}
 		w = fout
 		defer func() {
@@ -102,8 +116,7 @@ func main() {
 		`^[^\d]*(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z].+?))?(?:-(\d+)-g(.+?)(?:-(dirty))?)?\s*$`)
 	m := rx.FindStringSubmatch(gitdesc)
 	if len(m) == 0 {
-		fmt.Fprintf(os.Stderr, "error: match git describe failed: %s\n", gitdesc)
-		os.Exit(1)
+		errorExit(fmt.Sprintf("error: match git describe failed: %s\n", gitdesc))
 	}
 
 	goos := os.Getenv("XGOOS")
@@ -158,8 +171,7 @@ func main() {
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(ver); err != nil {
-			fmt.Fprintf(os.Stderr, "error: encode to json failed: %v\n", err)
-			os.Exit(1)
+			errorExit(fmt.Sprintf("error: encode to json failed: %v\n", err))
 		}
 	case "mk":
 		for _, v := range ver.EnvVars() {
@@ -168,22 +180,21 @@ func main() {
 			fmt.Fprintf(w, "%s ?=", key)
 			if len(p) == 1 {
 				fmt.Fprintln(w)
-				continue
+			} else {
+				val := p[1]
+				if strings.HasPrefix(val, `"`) &&
+					strings.HasSuffix(val, `"`) {
+					val = val[1 : len(val)-1]
+				}
+				val = strings.Replace(val, "$", "$$", -1)
+				fmt.Fprintf(w, " %s\n", val)
 			}
-			val := p[1]
-			if strings.HasPrefix(val, `"`) &&
-				strings.HasSuffix(val, `"`) {
-				val = val[1 : len(val)-1]
-			}
-			val = strings.Replace(val, "$", "$$", -1)
-			fmt.Fprintf(w, " %s\n", val)
 		}
 	case "rpm":
 		fmt.Fprintln(w, ver.RPM())
 	case "tpl":
 		if err := tpl.Execute(w, ver); err != nil {
-			fmt.Fprintf(os.Stderr, "error: template failed: %v\n", err)
-			os.Exit(1)
+			errorExit(fmt.Sprintf("error: template failed: %v\n", err))
 		}
 	case "ver":
 		fmt.Fprintln(w, ver.String())
@@ -196,22 +207,27 @@ func doExec(cmd string, args ...string) ([]byte, error) {
 	return c.Output()
 }
 
+func errorExit(message string) {
+	fmt.Fprintf(os.Stderr, "%s", message)
+	OSExit(1)
+}
+
 func chkErr(out []byte, err error) string {
 	if err == nil {
 		return strings.TrimSpace(string(out))
 	}
 
-	e, ok := err.(*exec.ExitError)
+	e, ok := GetExitError(err)
 	if !ok {
-		os.Exit(1)
+		OSExit(1)
 	}
 
-	st, ok := e.Sys().(syscall.WaitStatus)
+	status, ok := GetStatusError(e)
 	if !ok {
-		os.Exit(1)
+		OSExit(1)
 	}
 
-	os.Exit(st.ExitStatus())
+	OSExit(status)
 	return ""
 }
 
@@ -317,7 +333,7 @@ var goarchToUname = map[string]string{
 	"mips64le": "MIPS64LE",
 	"mipsle":   "MIPS32LE",
 	"ppc64":    "PPC64",
-	"ppc64le":  "PPC6sem4LE",
+	"ppc64le":  "PPC64LE",
 	"s390x":    "S390X",
 }
 
@@ -326,4 +342,28 @@ func fileExists(filePath string) bool {
 		return true
 	}
 	return false
+}
+
+// ReadFile is a wrapper around os.ReadFile
+var ReadFile = func(file string) ([]byte, error) {
+	return os.ReadFile(file) // #nosec G304
+}
+
+// OSExit is a wrapper around os.Exit
+var OSExit = func(code int) {
+	os.Exit(code)
+}
+
+// GetExitError is a wrapper around exec.ExitError
+var GetExitError = func(err error) (e *exec.ExitError, ok bool) {
+	e, ok = err.(*exec.ExitError)
+	return
+}
+
+// GetStatusError is a wrapper around syscall.WaitStatus
+var GetStatusError = func(exitError *exec.ExitError) (status int, ok bool) {
+	if e, ok := exitError.Sys().(syscall.WaitStatus); ok {
+		return e.ExitStatus(), true
+	}
+	return 1, false
 }

--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -201,7 +201,7 @@ func main() {
 	}
 }
 
-func doExec(cmd string, args ...string) ([]byte, error) {
+var doExec = func(cmd string, args ...string) ([]byte, error) {
 	c := exec.Command(cmd, args...) // #nosec G204
 	c.Stderr = os.Stderr
 	return c.Output()

--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -1,0 +1,329 @@
+/*
+ Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"text/template"
+	"time"
+)
+
+func main() {
+	var (
+		tpl    *template.Template
+		format string
+		output string
+		export bool
+	)
+
+	flag.StringVar(
+		&format,
+		"f",
+		"ver",
+		"The output format: env, go, json, mk, rpm, ver")
+	flag.StringVar(
+		&output,
+		"o",
+		"",
+		"The output file")
+	flag.BoolVar(
+		&export,
+		"x",
+		false,
+		"Export env vars. Used with -f env")
+	flag.Parse()
+
+	if strings.EqualFold("env", format) {
+		format = "env"
+	} else if strings.EqualFold("go", format) {
+		format = "go"
+	} else if strings.EqualFold("json", format) {
+		format = "json"
+	} else if strings.EqualFold("mk", format) {
+		format = "mk"
+	} else if strings.EqualFold("rpm", format) {
+		format = "rpm"
+	} else if strings.EqualFold("ver", format) {
+		format = "ver"
+	} else {
+		if fileExists(format) {
+			buf, err := os.ReadFile(format) // #nosec G304
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: read tpl failed: %v\n", err)
+				os.Exit(1)
+			}
+			format = string(buf)
+		}
+		tpl = template.Must(template.New("tpl").Parse(format))
+		format = "tpl"
+	}
+
+	var w io.Writer = os.Stdout
+	if len(output) > 0 {
+		fout, err := os.Create(filepath.Clean(output))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		w = fout
+		defer func() {
+			if err := fout.Close(); err != nil {
+				panic(err)
+			}
+		}() // #nosec G20
+	}
+
+	gitdesc := chkErr(doExec("git", "describe", "--long", "--dirty"))
+	rx := regexp.MustCompile(
+		`^[^\d]*(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z].+?))?(?:-(\d+)-g(.+?)(?:-(dirty))?)?\s*$`)
+	m := rx.FindStringSubmatch(gitdesc)
+	if len(m) == 0 {
+		fmt.Fprintf(os.Stderr, "error: match git describe failed: %s\n", gitdesc)
+		os.Exit(1)
+	}
+
+	goos := os.Getenv("XGOOS")
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	goarch := os.Getenv("XGOARCH")
+	if goarch == "" {
+		goarch = runtime.GOARCH
+	}
+	// get the build number. Jenkins exposes this as an
+	// env variable called BUILD_NUMBER
+	buildNumber := os.Getenv("BUILD_NUMBER")
+	if buildNumber == "" {
+		buildNumber = m[5]
+	}
+	buildType := os.Getenv("BUILD_TYPE")
+	if buildType == "" {
+		buildType = "X"
+	}
+	ver := &semver{
+		GOOS:   goos,
+		GOARCH: goarch,
+		OS:     goosToUname[goos],
+		Arch:   goarchToUname[goarch],
+		Major:  toInt(m[1]),
+		Minor:  toInt(m[2]),
+		Patch:  toInt(m[3]),
+		Notes:  m[4],
+		Type:   buildType,
+		Build:  toInt(buildNumber),
+		Sha7:   m[6],
+		Sha32:  chkErr(doExec("git", "log", "-n1", `--format=%H`)),
+		Dirty:  m[7] != "",
+		Epoch:  toInt64(chkErr(doExec("git", "log", "-n1", `--format=%ct`))),
+	}
+	ver.SemVer = ver.String()
+	ver.SemVerRPM = ver.RPM()
+	ver.BuildDate = ver.Timestamp().Format("Mon, 02 Jan 2006 15:04:05 MST")
+	ver.ReleaseDate = ver.Timestamp().Format("06-01-02")
+
+	switch format {
+	case "env":
+		for _, v := range ver.EnvVars() {
+			if export {
+				fmt.Fprint(w, "export ")
+			}
+			fmt.Fprintln(w, v)
+		}
+	case "go":
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(ver); err != nil {
+			fmt.Fprintf(os.Stderr, "error: encode to json failed: %v\n", err)
+			os.Exit(1)
+		}
+	case "mk":
+		for _, v := range ver.EnvVars() {
+			p := strings.SplitN(v, "=", 2)
+			key := p[0]
+			fmt.Fprintf(w, "%s ?=", key)
+			if len(p) == 1 {
+				fmt.Fprintln(w)
+				continue
+			}
+			val := p[1]
+			if strings.HasPrefix(val, `"`) &&
+				strings.HasSuffix(val, `"`) {
+				val = val[1 : len(val)-1]
+			}
+			val = strings.Replace(val, "$", "$$", -1)
+			fmt.Fprintf(w, " %s\n", val)
+		}
+	case "rpm":
+		fmt.Fprintln(w, ver.RPM())
+	case "tpl":
+		if err := tpl.Execute(w, ver); err != nil {
+			fmt.Fprintf(os.Stderr, "error: template failed: %v\n", err)
+			os.Exit(1)
+		}
+	case "ver":
+		fmt.Fprintln(w, ver.String())
+	}
+}
+
+func doExec(cmd string, args ...string) ([]byte, error) {
+	c := exec.Command(cmd, args...) // #nosec G204
+	c.Stderr = os.Stderr
+	return c.Output()
+}
+
+func chkErr(out []byte, err error) string {
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+
+	e, ok := err.(*exec.ExitError)
+	if !ok {
+		os.Exit(1)
+	}
+
+	st, ok := e.Sys().(syscall.WaitStatus)
+	if !ok {
+		os.Exit(1)
+	}
+
+	os.Exit(st.ExitStatus())
+	return ""
+}
+
+type semver struct {
+	GOOS        string `json:"goos"`
+	GOARCH      string `json:"goarch"`
+	OS          string `json:"os"`
+	Arch        string `json:"arch"`
+	Major       int    `json:"major"`
+	Minor       int    `json:"minor"`
+	Patch       int    `json:"patch"`
+	Build       int    `json:"build"`
+	Notes       string `json:"notes"`
+	Type        string `json:"type"`
+	Dirty       bool   `json:"dirty"`
+	Sha7        string `json:"sha7"`
+	Sha32       string `json:"sha32"`
+	Epoch       int64  `json:"epoch"`
+	SemVer      string `json:"semver"`
+	SemVerRPM   string `json:"semverRPM"`
+	BuildDate   string `json:"buildDate"`
+	ReleaseDate string `json:"releaseDate"`
+}
+
+func (v *semver) String() string {
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if len(v.Notes) > 0 {
+		fmt.Fprintf(buf, "-%s", v.Notes)
+	}
+	if v.Build > 0 {
+		fmt.Fprintf(buf, "+%d", v.Build)
+	}
+	if v.Dirty {
+		fmt.Fprint(buf, "+dirty")
+	}
+	return buf.String()
+}
+
+func (v *semver) RPM() string {
+	return strings.Replace(v.String(), "-", "+", -1)
+}
+
+func (v *semver) EnvVars() []string {
+	return []string{
+		fmt.Sprintf("GOOS=%s", v.GOOS),
+		fmt.Sprintf("GOARCH=%s", v.GOARCH),
+		fmt.Sprintf("OS=%s", v.OS),
+		fmt.Sprintf("ARCH=%s", v.Arch),
+		fmt.Sprintf("MAJOR=%d", v.Major),
+		fmt.Sprintf("MINOR=%d", v.Minor),
+		fmt.Sprintf("PATCH=%d", v.Patch),
+		fmt.Sprintf("BUILD=%3.3d", v.Build),
+		fmt.Sprintf("NOTES=\"%s\"", v.Notes),
+		fmt.Sprintf("TYPE=%s", v.Type),
+		fmt.Sprintf("DIRTY=%v", v.Dirty),
+		fmt.Sprintf("SHA7=%s", v.Sha7),
+		fmt.Sprintf("SHA32=%s", v.Sha32),
+		fmt.Sprintf("EPOCH=%d", v.Epoch),
+		fmt.Sprintf("SEMVER=\"%s\"", v.SemVer),
+		fmt.Sprintf("SEMVER_RPM=\"%s\"", v.SemVerRPM),
+		fmt.Sprintf("BUILD_DATE=\"%s\"", v.BuildDate),
+		fmt.Sprintf("RELEASE_DATE=\"%s\"", v.ReleaseDate),
+	}
+}
+
+func (v *semver) Timestamp() time.Time {
+	return time.Unix(v.Epoch, 0)
+}
+
+func toInt(sz string) int {
+	i, _ := strconv.Atoi(sz)
+	return i
+}
+
+func toInt64(sz string) int64 {
+	i, _ := strconv.Atoi(sz)
+	return int64(i)
+}
+
+var goosToUname = map[string]string{
+	"android":   "Android",
+	"darwin":    "Darwin",
+	"dragonfly": "DragonFly",
+	"freebsd":   "kFreeBSD",
+	"linux":     "Linux",
+	"nacl":      "NaCl",
+	"netbsd":    "NetBSD",
+	"openbsd":   "OpenBSD",
+	"plan9":     "Plan9",
+	"solaris":   "Solaris",
+	"windows":   "Windows",
+}
+
+var goarchToUname = map[string]string{
+	"386":      "i386",
+	"amd64":    "x86_64",
+	"amd64p32": "x86_64_P32",
+	"arm":      "ARMv7",
+	"arm64":    "ARMv8",
+	"mips":     "MIPS32",
+	"mips64":   "MIPS64",
+	"mips64le": "MIPS64LE",
+	"mipsle":   "MIPS32LE",
+	"ppc64":    "PPC64",
+	"ppc64le":  "PPC6sem4LE",
+	"s390x":    "S390X",
+}
+
+func fileExists(filePath string) bool {
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		return true
+	}
+	return false
+}

--- a/core/semver/semver_test.go
+++ b/core/semver/semver_test.go
@@ -1,0 +1,273 @@
+/*
+ Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainFunction(t *testing.T) {
+	tests := []struct {
+		name            string
+		format          string
+		outputFile      string
+		expectEmptyFile bool
+		readFileFunc    func(file string) ([]byte, error)
+	}{
+		{
+			name:       "Write mk format to file",
+			format:     "mk",
+			outputFile: "test_output.mk",
+		},
+		{
+			name:       "Write env format to file",
+			format:     "env",
+			outputFile: "test_output.env",
+		},
+		{
+			name:       "Write json format to file",
+			format:     "json",
+			outputFile: "test_output.json",
+		},
+		{
+			name:       "Write ver format to file",
+			format:     "ver",
+			outputFile: "test_output.ver",
+		},
+		{
+			name:       "Write rpm format to file",
+			format:     "rpm",
+			outputFile: "test_output.rpm",
+		},
+		{
+			name:       "Write tpl format to file",
+			format:     "../semver.tpl",
+			outputFile: "test_output.rpm",
+		},
+		{
+			name:       "Write tpl format to file but error reading source file",
+			format:     "../semver.tpl",
+			outputFile: "test_output.rpm",
+			readFileFunc: func(_ string) ([]byte, error) {
+				return nil, errors.New("error reading source file")
+			},
+			expectEmptyFile: true,
+		},
+		{
+			// go format currently does not print any output, expect an empty file
+			name:            "Write go format to file",
+			format:          "go",
+			outputFile:      "test_output.go",
+			expectEmptyFile: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			osArgs := os.Args
+			os.Args = append(os.Args, "-f", tt.format)
+			os.Args = append(os.Args, "-o", tt.outputFile)
+			os.Args = append(os.Args, "-x", "true")
+
+			oldReadFile := ReadFile
+			if tt.readFileFunc != nil {
+				ReadFile = tt.readFileFunc
+			}
+			oldOSExit := OSExit
+			OSExit = func(_ int) {}
+
+			main()
+
+			// Open the file
+			file, err := os.Open(tt.outputFile)
+			if err != nil {
+				t.Error(err)
+			}
+			defer file.Close()
+
+			// Read the file contents
+			contents, err := io.ReadAll(file)
+			if err != nil {
+				t.Error(err)
+			}
+
+			defer os.Remove(tt.outputFile)
+
+			// make sure file is not empty
+			if tt.expectEmptyFile {
+				assert.Equal(t, 0, len(contents))
+			} else {
+				assert.NotEqual(t, 0, len(contents))
+			}
+			os.Args = osArgs
+			ReadFile = oldReadFile
+			OSExit = oldOSExit
+		})
+	}
+}
+
+func TestChkErr(t *testing.T) {
+	tests := []struct {
+		name           string
+		out            []byte
+		err            error
+		wantOut        string
+		wantErr        bool
+		getExitError   func(err error) (*exec.ExitError, bool)
+		getStatusError func(exitError *exec.ExitError) (int, bool)
+	}{
+		{
+			name:    "No error",
+			out:     []byte("output"),
+			err:     nil,
+			wantOut: "output",
+			wantErr: false,
+			getExitError: func(_ error) (*exec.ExitError, bool) {
+				return nil, true
+			},
+			getStatusError: func(_ *exec.ExitError) (int, bool) {
+				return 0, true
+			},
+		},
+		{
+			name:    "Error with command",
+			out:     []byte("output"),
+			err:     errors.New("error"),
+			wantOut: "",
+			wantErr: true,
+			getExitError: func(_ error) (*exec.ExitError, bool) {
+				return nil, false
+			},
+			getStatusError: func(_ *exec.ExitError) (int, bool) {
+				return 1, false
+			},
+		},
+		{
+			name:    "Error casting to ExitError",
+			out:     []byte("output"),
+			err:     errors.New("error"),
+			wantOut: "",
+			wantErr: true,
+			getExitError: func(_ error) (*exec.ExitError, bool) {
+				return nil, true
+			},
+			getStatusError: func(_ *exec.ExitError) (int, bool) {
+				return 1, false
+			},
+		},
+		{
+			name:    "Error getting status from ExitError",
+			out:     []byte("output"),
+			err:     errors.New("error"),
+			wantOut: "",
+			wantErr: true,
+			getExitError: func(_ error) (*exec.ExitError, bool) {
+				return nil, false
+			},
+			getStatusError: func(_ *exec.ExitError) (int, bool) {
+				return 0, true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			GetExitError = tt.getExitError
+			GetStatusError = tt.getStatusError
+			OSExit = func(_ int) {}
+
+			gotOut := chkErr(tt.out, tt.err)
+			if gotOut != tt.wantOut {
+				t.Errorf("chkErr() gotOut = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{
+			name:     "File exists",
+			filePath: "semver.go",
+			want:     true,
+		},
+		{
+			name:     "File does not exist",
+			filePath: "non-existent.txt",
+			want:     false,
+		},
+		{
+			name:     "File path is empty",
+			filePath: "",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fileExists(tt.filePath)
+			if got != tt.want {
+				t.Errorf("fileExists(%s) = %v, want %v", tt.filePath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorExit(t *testing.T) {
+	message := "error message"
+
+	if os.Getenv("INVOKE_ERROR_EXIT") == "1" {
+		errorExit(message)
+		return
+	}
+	// call the test again with INVOKE_ERROR_EXIT=1 so the errorExit function is invoked and we can check the return code
+	cmd := exec.Command(os.Args[0], "-test.run=TestErrorExit") // #nosec G204
+	cmd.Env = append(os.Environ(), "INVOKE_ERROR_EXIT=1")
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		fmt.Println("Error creating stderr pipe:", err)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Error(err)
+	}
+
+	buf := make([]byte, 1024)
+	n, err := stderr.Read(buf)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = cmd.Wait()
+	if e, ok := err.(*exec.ExitError); ok && e.Success() {
+		t.Error(err)
+	}
+
+	// check the output is the message we logged in errorExit
+	assert.Equal(t, message, string(buf[:n]))
+}

--- a/core/semver/semver_test.go
+++ b/core/semver/semver_test.go
@@ -1,6 +1,5 @@
 /*
  Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
-
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -243,6 +242,10 @@ func TestErrorExit(t *testing.T) {
 		errorExit(message)
 		return
 	}
+	// Set GOCOVERDIR to a temporary directory
+	tmpDir := t.TempDir()
+	os.Setenv("GOCOVERDIR", tmpDir)
+
 	// call the test again with INVOKE_ERROR_EXIT=1 so the errorExit function is invoked and we can check the return code
 	cmd := exec.Command(os.Args[0], "-test.run=TestErrorExit") // #nosec G204
 	cmd.Env = append(os.Environ(), "INVOKE_ERROR_EXIT=1")

--- a/core/semver/semver_test.go
+++ b/core/semver/semver_test.go
@@ -20,12 +20,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetStatusError(t *testing.T) {
+func TestGetStatusError(_ *testing.T) {
 	exitError := &exec.ExitError{
 		ProcessState: &os.ProcessState{},
 	}
@@ -295,6 +296,12 @@ func TestErrorExit(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Trim the warning message from the actual output
+	actualMessage := string(buf[:n])
+	if idx := strings.Index(actualMessage, "warning: GOCOVERDIR not set"); idx != -1 {
+		actualMessage = actualMessage[:idx]
+	}
+
 	// check the output is the message we logged in errorExit
-	assert.Equal(t, message, string(buf[:n]))
+	assert.Equal(t, message, actualMessage)
 }

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,30 @@
+# Copyright (c) 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Includes the following generated file to get semantic version information
+include semver.mk
+
+ifeq ($(VERSION),)
+VERSION?="v$(MAJOR).$(MINOR).$(PATCH)"
+endif
+
+REGISTRY?="${REGISTRY_HOST}:${REGISTRY_PORT}/podmon"
+
+podman: download-csm-common
+	$(eval include csm-common.mk)
+	@echo "MAJOR $(MAJOR) MINOR $(MINOR) PATCH $(PATCH) RELNOTE $(RELNOTE) SEMVER $(SEMVER)"
+	podman build --pull --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) --build-arg BASEIMAGE=$(CSM_BASEIMAGE) -f ./Dockerfile --label commit=$(shell git log --max-count 1 --format="%H") .
+
+push:
+	podman push "$(REGISTRY):$(VERSION)"
+

--- a/docker.mk
+++ b/docker.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2021-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@ endif
 
 REGISTRY?="${REGISTRY_HOST}:${REGISTRY_PORT}/podmon"
 
-podman: download-csm-common
-	$(eval include csm-common.mk)
-	@echo "MAJOR $(MAJOR) MINOR $(MINOR) PATCH $(PATCH) RELNOTE $(RELNOTE) SEMVER $(SEMVER)"
+podman:
 	podman build --pull --no-cache -t "$(REGISTRY):$(VERSION)" --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) --build-arg BASEIMAGE=$(CSM_BASEIMAGE) -f ./Dockerfile --label commit=$(shell git log --max-count 1 --format="%H") .
 
 push:

--- a/docker.mk
+++ b/docker.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Added support for semver.go
Set image VERSION through semver.mk and removed the unnecessary hardcoded fields

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1490 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built and tagged podman image successfully 
```
[root@lglw3182 karavi-resiliency]# make podman
curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk
...
go run core/semver/semver.go -f mk >semver.mk
make -f docker.mk podman DEFAULT_GOIMAGE=golang:1.23 CSM_BASEIMAGE=quay.io/dell/container-storage-modules/csm-base-image:nightly
make[1]: Entering directory '/root/riya/image_version_test/karavi-resiliency'
MAJOR 1 MINOR 12 PATCH 0 RELNOTE  SEMVER 1.12.0+3+dirty
podman build --pull --no-cache -t ""10.247.98.98:5000/podmon":"v1.12.0"" --build-arg GOIMAGE=golang:1.23 --build-arg BASEIMAGE=quay.io/dell/container-storage-modules/csm-base-image:nightly -f ./Dockerfile --label commit=0bf43a6e2aeef70fd0f15584592a5f17b923cfc7 .
[1/2] STEP 1/4: FROM golang:1.23 AS builder
...
[2/2] COMMIT 10.247.98.98:5000/podmon:v1.12.0
--> bdf9c71bf1b4
Successfully tagged 10.247.98.98:5000/podmon:v1.12.0
bdf9c71bf1b4e3cc1ebe5cc034af109131a29837c97fe42b951a9be3e94da5b9
make[1]: Leaving directory '/root/riya/image_version_test/karavi-resiliency'
```

- [x] Ran test for newly added semver_test.go file
`PASS: coverage for package podmon/core/semver is 92.1%, not lower than 90%`
