### PR TITLE
Changes to get Resiliency E2E tests to run on PowerMax (OCP)

### DIFF
--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -380,7 +380,7 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure       | failSecs | deploySecs | runSecs | nodeCleanSecs |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nfs"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-iscsi"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
+      | ""         | "1-1"       | "1-1" | "1-1" | "powermax"    | "powermax-iscsi"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nvmetcp"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
 
   @powerflex-integration

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -41,7 +41,7 @@ Feature: Integration Test
     Examples:
       | kubeConfig | driverNames             | namespace | name    | storageClasses          |
       | ""         | "csi-isilon.dellemc.com" | "isilon"   | "isilon" | "isilon" |
-  
+
   @powerstore-int-setup-check
   Scenario Outline: Validate that we have a valid k8s configuration for the integration tests
     Given a kubernetes <kubeConfig>
@@ -154,7 +154,7 @@ Feature: Integration Test
      # Small number of pods, increasing number of vols and devs
       | ""         | "1-2"       | "1-1" | "0-0" | "isilon"    | "isilon" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 600     | 600           |
       | ""         | "3-5"       | "2-2" | "0-0" | "isilon"    | "isilon" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           |
-  
+
   @powerstore-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
@@ -379,7 +379,7 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure       | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nfs"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
+      #| ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nfs"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
       | ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-iscsi"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nvmetcp"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
 
@@ -527,7 +527,7 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | nodeCleanSecs |
       | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"      | "one-third" | "zero"  | "interfacedown" | 600      | 900        | 900           |
-  
+
   @powerstore-integration
   Scenario Outline: Deploy pods when there are failed nodes already
     Given a kubernetes <kubeConfig>
@@ -673,7 +673,7 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
       | ""         | "1-1"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
-  
+
   @powerstore-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
@@ -709,7 +709,7 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
+      #| ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
       | ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-iscsi"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-nvmetcp"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
 
@@ -870,7 +870,7 @@ Feature: Integration Test
       | ""         | "3-5"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 600      | 900        | 900     | 1800           |
     # | ""         | "3-5"       | "2-2" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 240      | 240        | 300     | 600           |
     # | ""         | "5-10"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 1200      | 2000       | 2000     | 2000           |
-  
+
   @powerstore-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node slow reboots)
     Given a kubernetes <kubeConfig>
@@ -958,7 +958,7 @@ Feature: Integration Test
     Then finally cleanup everything
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass     | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-nfs"   | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 600           |
+      #| ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-nfs"   | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 600           |
       | ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-iscsi" | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 600           |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-nvmetcp"   | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 600          |
 
@@ -993,9 +993,9 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass   | workers     | primary | failure     |  taints                          | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"    | "one-third" | "zero"  | "driverpod" | "offline.unity.storage.dell.com" | 120      | 300        | 300     | 600           | 
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-nfs"    | "one-third" | "zero"  | "driverpod" | "offline.unity.storage.dell.com" | 120      | 300        | 300     | 600           |
       | ""         | "1-3"       | "2-2" | "0-0" | "unity"    | "unity-nfs"    | "one-third" | "zero"  | "driverpod" | "offline.unity.storage.dell.com" | 120      | 300        | 300     | 600           |
-      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-iscsi"  | "one-third" | "zero"  | "driverpod" | "offline.unity.storage.dell.com" | 120      | 300        | 300     | 600           | 
+      | ""         | "1-2"       | "1-1" | "0-0" | "unity"    | "unity-iscsi"  | "one-third" | "zero"  | "driverpod" | "offline.unity.storage.dell.com" | 120      | 300        | 300     | 600           |
       | ""         | "1-3"       | "2-2" | "0-0" | "unity"    | "unity-iscsi"  | "one-third" | "zero"  | "driverpod" | "offline.unity.storage.dell.com" | 120      | 300        | 300     | 600           |
 
 @powerstore-integration
@@ -1011,11 +1011,11 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType    | storageClass          | workers     | primary | failure     |  taints                               | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-2"       | "1-1" | "0-0" | "powerstore"  | "powerstore-nfs"      | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           | 
+      | ""         | "1-2"       | "1-1" | "0-0" | "powerstore"  | "powerstore-nfs"      | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           |
       | ""         | "1-3"       | "2-2" | "0-0" | "powerstore"  | "powerstore-nfs"      | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           |
-      | ""         | "1-2"       | "1-1" | "0-0" | "powerstore"  | "powerstore-iscsi"    | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           | 
+      | ""         | "1-2"       | "1-1" | "0-0" | "powerstore"  | "powerstore-iscsi"    | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           |
       | ""         | "1-3"       | "2-2" | "0-0" | "powerstore"  | "powerstore-iscsi"    | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           |
-      #| ""         | "1-2"       | "1-1" | "0-0" | "powerstore"  | "powerstore-nvmetcp"  | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           | 
+      #| ""         | "1-2"       | "1-1" | "0-0" | "powerstore"  | "powerstore-nvmetcp"  | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           |
       #| ""         | "1-3"       | "2-2" | "0-0" | "powerstore"  | "powerstore-nvmetcp"  | "one-third" | "zero"  | "driverpod" | "offline.powerstore.storage.dell.com" | 120      | 300        | 300     | 600           |
 
   @powerstore-short-integration
@@ -1105,6 +1105,6 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType    | storageClass          | workers     | primary | failure     |  taints                               | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nfs"        | "one-third" | "zero"  | "driverpod" | "offline.powermax.storage.dell.com"   | 120      | 300        | 300     | 600           |
+      #| ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-nfs"        | "one-third" | "zero"  | "driverpod" | "offline.powermax.storage.dell.com"   | 120      | 300        | 300     | 600           |
       | ""         | "1-1"       | "1-1" | "0-0" | "powermax"    | "powermax-iscsi"      | "one-third" | "zero"  | "driverpod" | "offline.powermax.storage.dell.com"   | 120      | 300        | 300     | 600           |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powermax"  | "powermax-nvmetcp"  | "one-third" | "zero"  | "driverpod" | "offline.powermax.storage.dell.com" | 120      | 300        | 300     | 600           |


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
This PR comments out the test cases in the powremax-short-integration tests that require the powermax-nfs storageclass. These test scenarios cause the tests to fail on OCP even when that storageclass exists. Commenting out these test cases gets the whole Resiliency E2E test suite to run successfully on PowerMax. 

Note:
Currently the tests are not passing. The first powermax short integration test is failing due to an error involving unassigned taints. After thorough investigation, it was determined that this is an issue with resiliency so the following defect was raised: [ECS01E-371](https://jira.cec.lab.emc.com/browse/ECS01E-371). Resolving this defect will get the tests to pass.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| N/A |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Resiliency E2E running on PowerMax (1): https://osj-sio-03-prd.cec.lab.emc.com/view/Container-Storage-Modules/job/Container-Storage-Modules/job/CSM-Pipeline-Sandbox/job/test-pipelines/job/techops-test-pipelines/job/pmax-res-tests/173/
- [x] Resiliency E2E running on PowerMax (2): https://osj-sio-03-prd.cec.lab.emc.com/view/Container-Storage-Modules/job/Container-Storage-Modules/job/CSM-Pipeline-Sandbox/job/test-pipelines/job/techops-test-pipelines/job/pmax-res-tests/181/
