### PR TITLE
Increase timeout for Resiliency test for Powerscale

### DIFF
--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -284,9 +284,9 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure       | failSecs | deploySecs | runSecs | nodeCleanSecs |
       # Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"    | "isilon"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"    | "isilon"  | "one-third" | "zero"  | "kubeletdown" | 600      | 1800        | 1800     | 1800           |
       # Slightly more pods, increasing number of vols and devs
-      | ""         | "3-5"       | "1-1" | "0-0" | "isilon"    | "isilon"  | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
+      | ""         | "3-5"       | "1-1" | "0-0" | "isilon"    | "isilon"  | "one-third" | "zero"  | "kubeletdown" | 600      | 1800        | 1800     | 1800           |
 
   @powerstore-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node kubelet down)
@@ -526,7 +526,7 @@ Feature: Integration Test
     Then finally cleanup everything
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | nodeCleanSecs |
-      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"      | "one-third" | "zero"  | "interfacedown" | 600      | 1800        | 900           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"      | "one-third" | "zero"  | "interfacedown" | 600      | 1800        | 1800           |
   
   @powerstore-integration
   Scenario Outline: Deploy pods when there are failed nodes already
@@ -864,8 +864,8 @@ Feature: Integration Test
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
        #Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 900           |
-      | ""         | "1-2"       | "2-2" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 600      | 900        | 900     | 1200           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 1800           |
+      | ""         | "1-2"       | "2-2" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 600      | 1800        | 1800     | 1200           |
       # Slightly more pods, increasing number of vols and devs
       | ""         | "3-5"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 600      | 900        | 900     | 1800           |
     # | ""         | "3-5"       | "2-2" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 240      | 240        | 300     | 600           |
@@ -1051,7 +1051,7 @@ Feature: Integration Test
       Examples:
         | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
         | ""         | "1-2"       | "1-1" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 240      | 600        | 600     | 600          |
-        | ""         | "1-2"       | "2-2" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 600      | 900        | 900     | 900           |
+        | ""         | "1-2"       | "2-2" | "0-0" | "isilon" | "isilon"   | "one-third" | "zero"  | "reboot" | 600      | 1800        | 1800     | 1800           |
 
 
   @powerscale-short-integration
@@ -1069,8 +1069,8 @@ Feature: Integration Test
 
       Examples:
         | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure       | failSecs | deploySecs | runSecs | nodeCleanSecs |
-        | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
-        | ""         | "3-5"       | "1-1" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 900     | 900           |
+        | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "kubeletdown" | 600      | 1800        | 1800     | 1800           |
+        | ""         | "3-5"       | "1-1" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "kubeletdown" | 600      | 1800        | 1800     | 1800           |
 
   @powermax-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (driver pods down)

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -526,7 +526,7 @@ Feature: Integration Test
     Then finally cleanup everything
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | nodeCleanSecs |
-      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"      | "one-third" | "zero"  | "interfacedown" | 600      | 900        | 900           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"      | "one-third" | "zero"  | "interfacedown" | 600      | 1800        | 900           |
   
   @powerstore-integration
   Scenario Outline: Deploy pods when there are failed nodes already


### PR DESCRIPTION
E2E Test for powerscale was failing with error:
```
time="2025-05-02T10:32:09-05:00" level=info msg="Done checking if all nodes are ready after 15m0.004054059s"
      | [31m""[0m         | [31m"1-2"[0m       | [31m"2-2"[0m | [31m"0-0"[0m | [31m"isilon"[0m   | [31m"isilon"[0m     | [31m"one-third"[0m | [31m"zero"[0m  | [31m"reboot"[0m | [31m600[0m      | [31m900[0m        | [31m900[0m     | [31m900[0m           |
        [1;31m
	Error Trace:	/****/karavi-resiliency/internal/monitor/monitor_test_helpers.go:29
	            				/****/karavi-resiliency/internal/monitor/integration_steps_test.go:1478
	            				/****/karavi-resiliency/internal/monitor/integration_steps_test.go:543
	            				/usr/local/go/src/reflect/value.go:584
	            				/usr/local/go/src/reflect/value.go:368
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/internal/models/stepdef.go:189
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/suite.go:287
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/suite.go:576
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/suite.go:638
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/run.go:124
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/run.go:135
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/run.go:284
	            				/go/pkg/mod/github.com/cucumber/godog@v0.15.0/run.go:348
	            				/****/karavi-resiliency/internal/monitor/short_integration_test.go:297
	Error:      	Not equal: 
	            	expected: true
	            	actual  : false
	Messages:   	Expected all nodes to be 'Ready' in 900 seconds
```
This change will increase the timeout from 900 to 1800 seconds.



| GitHub Issue # |
| https://jira.cec.lab.emc.com/browse/ECS01B-161 |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

How Has This Been Tested?
https://osj-sio-03-prd.cec.lab.emc.com/view/Container-Storage-Modules/job/Container-Storage-Modules/job/CSM-Pipeline-Sandbox/job/test-pipelines/job/sanity-test-pipelines/job/sahiba-sanity-pipeline/442/
