### PR TITLE
Add Preferred-site node failure scenario for metro resiliency

### DIFF
--- a/internal/monitor/Makefile
+++ b/internal/monitor/Makefile
@@ -85,6 +85,14 @@ powerstore-integration-test:
 	SCRIPTS_DIR="../../test/sh" \
 	go test -timeout 6h -test.v -test.run "^\QTestPowerStoreFirstCheck\E|\QTestPowerStoreIntegration\E"
 
+powerstore-metro-integration-test:
+	RESILIENCY_INT_TEST="true" \
+	RESILIENCY_TEST_CLEANUP="true" \
+	POLL_K8S="true" \
+	SCRIPTS_DIR="../../test/sh" \
+	POWERSTORE_METRO="true" \
+	go test -timeout 6h -test.v -test.run "^\QTestPowerStoreFirstCheck\E|\QTestPowerStoreMetroIntegration\E"
+
 powermax-integration-test:
 	RESILIENCY_INT_TEST="true" \
 	RESILIENCY_TEST_CLEANUP="true" \

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -198,6 +198,24 @@ Feature: Integration Test
       #| ""         | "1-2"       | "1-1" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 600     | 600           |
       #| ""         | "3-5"       | "2-2" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           |
 
+  @powerstore-short-integration @powerstore-metro-resiliency
+  Scenario Outline: Preferred site node failover testing using test StatefulSet pods (node interface down)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And label <primary> node as <preferred> site
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
+    Then validate that all pods are running within <deploySecs> seconds
+    And all pods are running on <primary> node
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
+      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-iscsi"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           | "site"|
 
 
   @unity-integration
@@ -710,25 +728,6 @@ Feature: Integration Test
       #| ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-nfs"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
       #| ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-iscsi"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
       | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-nvmetcp"   | "one-third" | "zero"  | "interfacedown" | 240      | 480        | 300     | 300           |
-
-  @powerstore-short-integration
-  Scenario Outline: Preferred site node failover testing using test StatefulSet pods (node interface down)
-    Given a kubernetes <kubeConfig>
-    And cluster is clean of test pods
-    And wait <nodeCleanSecs> to see there are no taints
-    And label <primary> node as <preferred> site
-    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
-    Then validate that all pods are running within <deploySecs> seconds
-    And all pods are running on <primary> node
-    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
-    Then validate that all pods are running within <runSecs> seconds
-    And labeled pods are on a different node
-    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
-    Then finally cleanup everything
-
-    Examples:
-      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-nvmetcp"   | "one-third" | "zero"  | "interfacedown" | 240      | 480        | 300     | 300           | "site"|
 
   @powermax-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -198,7 +198,7 @@ Feature: Integration Test
       #| ""         | "1-2"       | "1-1" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 600     | 600           |
       #| ""         | "3-5"       | "2-2" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           |
 
-  @powerstore-integration @powerstore-metro-resiliency
+  @powerstore-integration @powerstore-metro-integration
   Scenario Outline: Preferred cluster node failure hosting metro volumes testing using StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -53,7 +53,21 @@ Feature: Integration Test
     And can logon to nodes and drop test scripts
     Examples:
       | kubeConfig | driverNames                  | namespace      | name         | storageClasses                                       |
-      | ""         | "csi-powerstore.dellemc.com" | "powerstore"   | "powerstore" | "powerstore-nfs,powerstore-iscsi,powerstore-nvmetcp,powerstore-metro" |
+      | ""         | "csi-powerstore.dellemc.com" | "powerstore"   | "powerstore" | "powerstore-nfs,powerstore-iscsi,powerstore-nvmetcp" |
+  
+  @powerstore-metro-int-setup-check
+  Scenario Outline: Validate that we have a valid k8s configuration for the PowerStore metro integration tests
+    Given a kubernetes <kubeConfig>
+    And test environmental variables are set
+    And these CSI driver <driverNames> are configured on the system
+    And these storageClasses <storageClasses> exist in the cluster
+    And there is a <namespace> in the cluster
+    And there are driver pods in <namespace> with this <name> prefix
+    And can logon to nodes and drop test scripts
+    Examples:
+      | kubeConfig | driverNames                  | namespace      | name         | storageClasses                                       |
+      | ""         | "csi-powerstore.dellemc.com" | "powerstore"   | "powerstore" | "powerstore-metro" |
+
 
   @powermax-int-setup-check
   Scenario Outline: Validate that we have a valid k8s configuration for the integration tests

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -199,7 +199,7 @@ Feature: Integration Test
       #| ""         | "3-5"       | "2-2" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           |
 
   @powerstore-integration @powerstore-metro-resiliency
-  Scenario Outline: Preferred site node failover testing using test StatefulSet pods (node interface down)
+  Scenario Outline: Preferred cluster node failure hosting metro volumes testing using StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
     And wait <nodeCleanSecs> to see there are no taints

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -207,7 +207,7 @@ Feature: Integration Test
     And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
     Then validate that all pods are running within <deploySecs> seconds
     And all pods are running on <preferred> node
-    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    When I fail labeled <preferred> nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
     And labeled pods are on a different node
     And the taints for the failed nodes are removed within <nodeCleanSecs> seconds

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -198,15 +198,15 @@ Feature: Integration Test
       #| ""         | "1-2"       | "1-1" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 120      | 600        | 600     | 600           |
       #| ""         | "3-5"       | "2-2" | "0-0" | "powerstore"    | "powerstore-nvmetcp" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           |
 
-  @powerstore-short-integration @powerstore-metro-resiliency
+  @powerstore-integration @powerstore-metro-resiliency
   Scenario Outline: Preferred site node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>
     And cluster is clean of test pods
     And wait <nodeCleanSecs> to see there are no taints
-    And label <primary> node as <preferred> site
+    And label <workers> node as <preferred> site
     And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
     Then validate that all pods are running within <deploySecs> seconds
-    And all pods are running on <primary> node
+    And all pods are running on <preferred> node
     When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <runSecs> seconds
     And labeled pods are on a different node
@@ -215,8 +215,7 @@ Feature: Integration Test
 
     Examples:
       | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
-      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-iscsi"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           | "site"|
-
+      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-metro"   | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           | "site"|
 
   @unity-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -711,6 +711,25 @@ Feature: Integration Test
       #| ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-iscsi"   | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |
       | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-nvmetcp"   | "one-third" | "zero"  | "interfacedown" | 240      | 480        | 300     | 300           |
 
+  @powerstore-short-integration
+  Scenario Outline: Preferred site node failover testing using test StatefulSet pods (node interface down)
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And label <primary> node as <preferred> site
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
+    Then validate that all pods are running within <deploySecs> seconds
+    And all pods are running on <primary> node
+    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <runSecs> seconds
+    And labeled pods are on a different node
+    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
+      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-nvmetcp"   | "one-third" | "zero"  | "interfacedown" | 240      | 480        | 300     | 300           | "site"|
+
   @powermax-short-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -53,7 +53,7 @@ Feature: Integration Test
     And can logon to nodes and drop test scripts
     Examples:
       | kubeConfig | driverNames                  | namespace      | name         | storageClasses                                       |
-      | ""         | "csi-powerstore.dellemc.com" | "powerstore"   | "powerstore" | "powerstore-nfs,powerstore-iscsi,powerstore-nvmetcp" |
+      | ""         | "csi-powerstore.dellemc.com" | "powerstore"   | "powerstore" | "powerstore-nfs,powerstore-iscsi,powerstore-nvmetcp,powerstore-metro" |
 
   @powermax-int-setup-check
   Scenario Outline: Validate that we have a valid k8s configuration for the integration tests

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -2081,7 +2081,7 @@ func (i *integration) deployProtectedPreferredPods(podsPerNode, numVols, numDevs
 	return i.deployPods(true, podsPerNode, numVols, numDevs, driverType, storageClass, wait, preferred)
 }
 
-func (i *integration) allPodsOnNode(preferred string) error {
+func (i *integration) allPodsOnNodesWithPreferredLabel(preferred string) error {
 	for podIdx := 1; podIdx <= i.podCount; podIdx++ {
 		for prefix := range i.testNamespacePrefix {
 			namespace := fmt.Sprintf("%s%d", prefix, podIdx)
@@ -2148,5 +2148,5 @@ func IntegrationTestScenarioInit(context *godog.ScenarioContext) {
 	context.Step(`^post failover disk content verification on all VMs succeeds$`, i.postFailoverVerifyAllVMs)
 	context.Step(`^label "([^"]*)" node as "([^"]*)" site$`, i.labelNodeAsPreferredSite)
 	context.Step(`^"([^"]*)" pods per node with "([^"]*)" volumes and "([^"]*)" devices using "([^"]*)" and "([^"]*)" in (\d+) with "([^"]*)" affinity$`, i.deployProtectedPreferredPods)
-	context.Step(`^all pods are running on "([^"]*)" node$`, i.allPodsOnNode)
+	context.Step(`^all pods are running on "([^"]*)" node$`, i.allPodsOnNodesWithPreferredLabel)
 }

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -816,6 +816,26 @@ func (i *integration) finallyCleanupEverything() error {
 
 	// Cleaned up, so zero the podCount
 	i.podCount = 0
+
+	// Clean up nodes with the label
+	labelKey := "preferred"
+	nodes, err := i.k8s.GetClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelKey,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes.Items {
+		if _, exists := node.Labels[labelKey]; exists {
+			delete(node.Labels, labelKey)
+			_, err := i.k8s.GetClient().CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/monitor/integration_test.go
+++ b/internal/monitor/integration_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	enableIntTestVar    = "RESILIENCY_INT_TEST"
-	enableStopOnFailure = "RESILIENCY_INT_TEST_STOP_ON_FAILURE"
+	enableIntTestVar      = "RESILIENCY_INT_TEST"
+	enableStopOnFailure   = "RESILIENCY_INT_TEST_STOP_ON_FAILURE"
+	enablePowerstoreMetro = "POWERSTORE_METRO"
 )
 
 var setupIsGood = false
@@ -144,10 +145,15 @@ func TestPowerStoreFirstCheck(t *testing.T) {
 	}
 	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
 
+	tag := "powerstore-int-setup-check"
+	if isMetro := os.Getenv(enablePowerstoreMetro); isMetro == "true" {
+		tag = "powerstore-metro-int-setup-check"
+	}
+
 	godogOptions := godog.Options{
 		Format:        "pretty,junit:powerstore-first-check-junit-report.xml,cucumber:powerstore-first-check-cucumber-report.json",
 		Paths:         []string{"features"},
-		Tags:          "powerstore-int-setup-check",
+		Tags:          tag,
 		StopOnFailure: stopOnFailure,
 	}
 	status := godog.TestSuite{

--- a/internal/monitor/integration_test.go
+++ b/internal/monitor/integration_test.go
@@ -347,6 +347,44 @@ func TestPowerStoreIntegration(t *testing.T) {
 	log.Printf("Integration test finished")
 }
 
+func TestPowerStoreMetroIntegration(t *testing.T) {
+	intTestEnvVarStr := os.Getenv(enableIntTestVar)
+	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {
+		log.Printf("Skipping integration test. To enable integration test: export %s=true", enableIntTestVar)
+		return
+	}
+
+	if !setupIsGood {
+		message := "The setup check failed. Tests skipped"
+		log.Print(message)
+		t.Error(message)
+		return
+	}
+
+	stopOnFailureStr := os.Getenv(enableStopOnFailure)
+	if stopOnFailureStr != "" && strings.ToLower(stopOnFailureStr) == "false" {
+		stopOnFailure = false
+	}
+	log.Printf("%s = %v", enableStopOnFailure, stopOnFailure)
+
+	log.Printf("Starting PowerStore Metro integration test")
+	godogOptions := godog.Options{
+		Format:        "pretty,junit:powerstore-metro-integration-junit-report.xml,cucumber:powerstore-metro-integration-cucumber-report.json",
+		Paths:         []string{"features"},
+		Tags:          "powerstore-metro-integration",
+		StopOnFailure: stopOnFailure,
+	}
+	status := godog.TestSuite{
+		Name:                "metro-integration",
+		ScenarioInitializer: IntegrationTestScenarioInit,
+		Options:             &godogOptions,
+	}.Run()
+	if status != 0 {
+		t.Error("There were failed metro integration tests")
+	}
+	log.Printf("Metro Integration test finished")
+}
+
 func TestPowerMaxIntegration(t *testing.T) {
 	intTestEnvVarStr := os.Getenv(enableIntTestVar)
 	if intTestEnvVarStr == "" || strings.ToLower(intTestEnvVarStr) != "true" {

--- a/test/podmontest/deploy/templates/test.yaml
+++ b/test/podmontest/deploy/templates/test.yaml
@@ -62,7 +62,7 @@ spec:
 {{end}}
 {{- if ne .Values.podmonTest.podPreferred ""}}
         affinity:
-          podAffinity:
+          nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1
               preference:

--- a/test/podmontest/deploy/templates/test.yaml
+++ b/test/podmontest/deploy/templates/test.yaml
@@ -60,6 +60,18 @@ spec:
                   - podmontest-{{ .Release.Namespace }}
               topologyKey: "kubernetes.io/hostname"
 {{end}}
+{{- if ne .Values.podmonTest.podPreferred ""}}
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: "preferred"
+                  operator: In
+                  values:
+                  - {{.Values.podmonTest.podPreferred}}
+{{end}}
         tolerations:
           - effect: NoExecute
             key: node.kubernetes.io/unreachable

--- a/test/podmontest/deploy/values-powerstore-iscsi.yaml
+++ b/test/podmontest/deploy/values-powerstore-iscsi.yaml
@@ -15,3 +15,5 @@ podmonTest:
   zone: ""
   # Number of seconds to tolerate a node unreachable taint
   unreachableTolerationSeconds: 300
+  # set to "preferred label" to enable pod preferred scheduling
+  podPreferred: ""

--- a/test/podmontest/deploy/values-powerstore-nfs.yaml
+++ b/test/podmontest/deploy/values-powerstore-nfs.yaml
@@ -17,4 +17,3 @@ podmonTest:
   unreachableTolerationSeconds: 300
   # set to "preferred label" to enable pod preferred scheduling
   podPreferred: ""
-  

--- a/test/podmontest/deploy/values-powerstore-nfs.yaml
+++ b/test/podmontest/deploy/values-powerstore-nfs.yaml
@@ -15,3 +15,5 @@ podmonTest:
   zone: ""
   # Number of seconds to tolerate a node unreachable taint
   unreachableTolerationSeconds: 300
+  # set to "preferred label" to enable pod preferred scheduling
+  podPreferred: ""

--- a/test/podmontest/deploy/values-powerstore-nfs.yaml
+++ b/test/podmontest/deploy/values-powerstore-nfs.yaml
@@ -17,3 +17,4 @@ podmonTest:
   unreachableTolerationSeconds: 300
   # set to "preferred label" to enable pod preferred scheduling
   podPreferred: ""
+  

--- a/test/podmontest/deploy/values-powerstore-nvme.yaml
+++ b/test/podmontest/deploy/values-powerstore-nvme.yaml
@@ -17,4 +17,3 @@ podmonTest:
   unreachableTolerationSeconds: 300
   # set to "preferred label" to enable pod preferred scheduling
   podPreferred: ""
-  

--- a/test/podmontest/deploy/values-powerstore-nvme.yaml
+++ b/test/podmontest/deploy/values-powerstore-nvme.yaml
@@ -15,3 +15,5 @@ podmonTest:
   zone: ""
   # Number of seconds to tolerate a node unreachable taint
   unreachableTolerationSeconds: 300
+  # set to "preferred label" to enable pod preferred scheduling
+  podPreferred: ""

--- a/test/podmontest/deploy/values-powerstore-nvme.yaml
+++ b/test/podmontest/deploy/values-powerstore-nvme.yaml
@@ -17,3 +17,4 @@ podmonTest:
   unreachableTolerationSeconds: 300
   # set to "preferred label" to enable pod preferred scheduling
   podPreferred: ""
+  

--- a/test/podmontest/insps.sh
+++ b/test/podmontest/insps.sh
@@ -31,6 +31,7 @@ driverLabel="csi-powerstore"
 podAffinity="false"
 unreachableTolerationSeconds=300
 workloadType=${workloadType:-"pod"}
+preferred=""
 
 if [ "$DEBUG"x != "x" ]; then
    DEBUG="--dry-run --debug"
@@ -92,6 +93,11 @@ do
      workloadType=$1
      shift
      ;;
+   "--podPreferred")
+     shift
+     preferred=$1
+     shift
+     ;;
  esac
 
 done
@@ -116,7 +122,8 @@ while [ $i -le $instances ]; do
               --set podmonTest.unreachableTolerationSeconds=$unreachableTolerationSeconds \
               --set podmonTest.image="$image" \
               --set podmonTest.zone="$zone" \
-              --set podmonTest.driverLabel="$driverLabel"
+              --set podmonTest.driverLabel="$driverLabel" \
+              --set podmonTest.podPreferred="$preferred"
  else
    helm install -n "${prefix}${i}" "${prefix}${i}" "${SCRIPTDIR}"/deploy \
      ${DEBUG} \


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Add a new scenario that fails node which are labeled as preferred site to test metro with Resiliency.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1961|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Unit test:
```
make unit-test:
PASS
coverage: 96.8% of statements
status 0
ok      podmon/cmd/podmon       1.578s  coverage: 96.8% of statements
make[1]: Leaving directory '/root/workspace/karavi-resiliency/cmd/podmon'
```
Integration test:
```
time="2025-08-06T21:10:01+01:00" level=info msg="k8sPoll: Node: worker-2-rjcs0evho6ev5.domain Ready:true Taints: "
    Given a kubernetes <kubeConfig>                                                                                                                        # <autogenerated>:1 -> *integration
    And cluster is clean of test pods                                                                                                                      # <autogenerated>:1 -> *integration
    And wait <nodeCleanSecs> to see there are no taints                                                                                                    # <autogenerated>:1 -> *integration
    And label <workers> node as <preferred> site                                                                                                           # <autogenerated>:1 -> *integration
    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <deploySecs> seconds                                                                                    # <autogenerated>:1 -> *integration
    And all pods are running on <preferred> node                                                                                                           # <autogenerated>:1 -> *integration
    When I fail labeled <preferred> nodes with <failure> failure for <failSecs> seconds                                                                    # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <runSecs> seconds                                                                                       # <autogenerated>:1 -> *integration
    And labeled pods are on a different node                                                                                                               # <autogenerated>:1 -> *integration
    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds                                                                         # <autogenerated>:1 -> *integration
    Then finally cleanup everything                                                                                                                        # <autogenerated>:1 -> *integration

    Examples:
      | kubeConfig | podsPerNode | nVol  | nDev  | driverType   | storageClass       | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-metro" | "one-third" | "zero"  | "interfacedown" | 240      | 600        | 600     | 600           | "site"    |

1 scenarios (1 passed)
12 steps (12 passed)
7m37.729621083s
time="2025-08-06T21:10:03+01:00" level=info msg="Integration test finished"
--- PASS: TestPowerStoreIntegration (457.76s)
PASS
status 0
ok      podmon/internal/monitor 479.952s
```