### PR TITLE
Fix E2E test fails to deploy for drivers other than powerstore

### DIFF
--- a/test/podmontest/deploy/templates/test.yaml
+++ b/test/podmontest/deploy/templates/test.yaml
@@ -60,7 +60,7 @@ spec:
                   - podmontest-{{ .Release.Namespace }}
               topologyKey: "kubernetes.io/hostname"
 {{end}}
-{{- if ne .Values.podmonTest.podPreferred ""}}
+{{- if not (empty .Values.podmonTest.podPreferred) }}
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Fix a defect that deployment of drivers other than Powerstore will fail because no podPreferred value is passed in.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1999 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

```
 # bash insps.sh --instances 1 --storage-class powerstore-metro --nvolumes 1 --dry-run
1
namespace/pmtps1 created
NAME: pmtps1
LAST DEPLOYED: Mon Aug 25 15:45:43 2025
NAMESPACE: pmtps1
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
```
 # bash insi.sh --instances 1 --storage-class isilon --nvolumes 1
1
namespace/pmti1 created
NAME: pmti1
LAST DEPLOYED: Mon Aug 25 15:47:29 2025
NAMESPACE: pmti1
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
```
# bash inspm.sh --instances 1 --storage-class powermax --nvolumes 1
1
namespace/pmtpm1 created
NAME: pmtpm1
LAST DEPLOYED: Mon Aug 25 15:48:30 2025
NAMESPACE: pmtpm1
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
```
# bash insu.sh --instances 1 --storage-class unity --nvolumes 1
1
namespace/pmtu1 created
NAME: pmtu1
LAST DEPLOYED: Mon Aug 25 15:49:37 2025
NAMESPACE: pmtu1
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
```
 # bash insv.sh --instances 1 --storage-class vxflexos --nvolumes 1
1
namespace/pmtv1 created
NAME: pmtv1
LAST DEPLOYED: Mon Aug 25 15:50:33 2025
NAMESPACE: pmtv1
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
Powerstore metro-resiliency e2e test:
```
3 scenarios (3 passed)
42 steps (29 passed, 13 skipped)
18m45.317257301s
time="2025-08-25T20:14:14+01:00" level=info msg="Metro Integration test finished"
--- PASS: TestPowerStoreMetroIntegration (1125.35s)
PASS
status 0
ok      podmon/internal/monitor 1145.245s
```