### PR TITLE
IntTest :non-preferred worker node down

### DIFF
--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -336,7 +336,7 @@ Feature: Integration Test
     And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
     Then validate that all pods are running within <deploySecs> seconds
     And all pods are running on <preferred> node
-    When I fail non-preferred nodes with <failure> failure for <failSecs> seconds
+    When I fail non <preferred> nodes with <failure> failure for <failSecs> seconds
     Then validate that all pods are running within <deploySecs> seconds
     And all pods are running on <preferred> node
     Then finally cleanup everything

--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -327,6 +327,24 @@ Feature: Integration Test
       | kubeConfig  | podsPerNode | nVol  | nDev  | driverNamespaceName | driverSecretName      | driverType    | storageClass        | workers     | migrateSecs | failSecs  | deploySecs  | nodeCleanSecs | runSecs | preferred | taint                                 |
       | ""          | "1-1"       | "1-1" | "0-0" | "powerstore"        | "powerstore-config"   | "powerstore"  | "powerstore-metro"  | "one-third" | 300         | 300       | 300         | 300           | 300     | "site"    | "powerstore.podmon.storage.dell.com"  |
 
+  @powerstore-integration @powerstore-metro-integration
+  Scenario Outline: All Non-Preferred-site Node Failure - Few nodes having preferred node labels not set
+    Given a kubernetes <kubeConfig>
+    And cluster is clean of test pods
+    And wait <nodeCleanSecs> to see there are no taints
+    And label <workers> node as <preferred> site
+    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity
+    Then validate that all pods are running within <deploySecs> seconds
+    And all pods are running on <preferred> node
+    When I fail non-preferred nodes with <failure> failure for <failSecs> seconds
+    Then validate that all pods are running within <deploySecs> seconds
+    And all pods are running on <preferred> node
+    Then finally cleanup everything
+
+    Examples:
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType   | storageClass         | workers      | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
+      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-metro"   | "one-half"   | "interfacedown" | 120      | 600        | 600     | 600           | "site"|
+
   @unity-integration
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)
     Given a kubernetes <kubeConfig>

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -322,7 +322,7 @@ func (i *integration) failLabeledNodes(preferred, failure string, wait int) erro
 }
 
 // failNonpreferredNodesWithFailureForSeconds fails non-preferred nodes with a specified failure for a given number of seconds.
-func (i *integration) failNonpreferredNodesWithFailureForSeconds(failure string, wait int) error {
+func (i *integration) failNonpreferredNodesWithFailureForSeconds(preferred string, failure string, wait int) error {
 	failedWorkers, err := i.failNodes(func(node corev1.Node) bool {
 		// check for only worker nodes
 		if isPrimaryNode(node) {
@@ -331,7 +331,7 @@ func (i *integration) failNonpreferredNodesWithFailureForSeconds(failure string,
 
 		// Check if the node's label indicates it's not a preferred site
 		val, ok := node.Labels["preferred"]
-		if !ok || val != "site" {
+		if !ok || val != preferred {
 			return true
 		}
 		return false
@@ -3072,5 +3072,5 @@ func IntegrationTestScenarioInit(context *godog.ScenarioContext) {
 	context.Step(`^nodes with pods and with "([^"]*)" label have taint "([^"]*)" within (\d+) seconds$`, i.labeledNodesWithPodsAreTainted)
 	context.Step(`^skip if "([^"]*)" is not compatible with "([^"]*)"$`, i.skipIfIsNotCompatibleWith)
 	context.Step(`^I set the correct driver type to "([^"]*)"$`, i.iSetTheCorrectDriverTypeTo)
-	context.Step(`^I fail non-preferred nodes with "([^"]*)" failure for (\d+) seconds$`, i.failNonpreferredNodesWithFailureForSeconds)
+	context.Step(`^I fail non "([^"]*)" nodes with "([^"]*)" failure for (\d+) seconds$`, i.failNonpreferredNodesWithFailureForSeconds)
 }

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -321,6 +321,33 @@ func (i *integration) failLabeledNodes(preferred, failure string, wait int) erro
 	return nil
 }
 
+// failNonpreferredNodesWithFailureForSeconds fails non-preferred nodes with a specified failure for a given number of seconds.
+func (i *integration) failNonpreferredNodesWithFailureForSeconds(failure string, wait int) error {
+	failedWorkers, err := i.failNodes(func(node corev1.Node) bool {
+		// check for only worker nodes
+		if isPrimaryNode(node) {
+			return false
+		}
+
+		// Check if the node's label indicates it's not a preferred site
+		val, ok := node.Labels["preferred"]
+		if !ok || val != "site" {
+			return true
+		}
+		return false
+	}, -1, failure, wait)
+	if err != nil {
+		return err
+	}
+
+	err = i.verifyExpectedNodesFailed(failedWorkers, wait)
+	if err != nil {
+		return fmt.Errorf("[failNonpreferredNodesWithFailureForSeconds] failed to verify expected nodes failed: %v", err)
+	}
+
+	return nil
+}
+
 func (i *integration) verifyExpectedNodesFailed(failedWorkers []string, wait int) error {
 	// Allow a little extra for node failure to be detected than just the node downtime.
 	// This proved necessary for the really short failure times (45 sec.) to be reliable.
@@ -3045,4 +3072,5 @@ func IntegrationTestScenarioInit(context *godog.ScenarioContext) {
 	context.Step(`^nodes with pods and with "([^"]*)" label have taint "([^"]*)" within (\d+) seconds$`, i.labeledNodesWithPodsAreTainted)
 	context.Step(`^skip if "([^"]*)" is not compatible with "([^"]*)"$`, i.skipIfIsNotCompatibleWith)
 	context.Step(`^I set the correct driver type to "([^"]*)"$`, i.iSetTheCorrectDriverTypeTo)
+	context.Step(`^I fail non-preferred nodes with "([^"]*)" failure for (\d+) seconds$`, i.failNonpreferredNodesWithFailureForSeconds)
 }


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
The added scenario deploys test pod on preferred node and brings down the non-preferred node and verifies that pod is still running.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Added test passed

    Given a kubernetes <kubeConfig>                                                                                                                       
    And cluster is clean of test pods                                                                                                                      
    And wait <nodeCleanSecs> to see there are no taints                                                                                   
    And label <workers> node as <preferred> site                                                                                              
    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> with <preferred> affinity 
    Then validate that all pods are running within <deploySecs> seconds                                                                                    
    And all pods are running on <preferred> node                                                                                                           
    When I fail non-preferred nodes with <failure> failure for <failSecs> seconds                                                          
    Then validate that all pods are running within <deploySecs> seconds                                                                       
    And all pods are running on <preferred> node                                                                                                           
    Then finally cleanup everything                                                                                                                        

    Examples:
      | kubeConfig | podsPerNode | nVol  | nDev  | driverType   | storageClass       | workers    | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs | preferred |
      | ""         | "1-1"       | "1-1" | "0-0" | "powerstore" | "powerstore-metro" | "one-half" | "interfacedown" | 120      | 600        | 600     | 600           | "site"    |

1 scenarios (1 passed)
11 steps (11 passed)
2m6.948632403s
INFO[0134] Metro Integration test finished
--- PASS: TestPowerStoreMetroIntegration (126.99s)
PASS

