### PR TITLE
Add retry mechanism to VM read and write operation 

### DIFF
--- a/internal/monitor/features/virtualization.feature
+++ b/internal/monitor/features/virtualization.feature
@@ -182,8 +182,8 @@ Feature: Virtual Machine Integration Test
 
     Examples:
       | kubeConfig | vmsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 600      | 600        | 600     | 600           |
-      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 900      | 900        | 900     | 900           |
+      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 600      | 600        | 1800     | 1800           |
+      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 900      | 900        | 1800     | 1800           |
 
   @powerflex-vm-integration
   Scenario Outline: Basic node failover testing using test VM's (node kubelet down)
@@ -202,8 +202,8 @@ Feature: Virtual Machine Integration Test
 
     Examples:
       | kubeConfig | vmsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
-      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "kubeletdown"   | 600      | 900        | 900     | 900           |
-      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "kubeletdown"   | 900      | 900        | 900     | 900           |
+      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "kubeletdown"   | 600      | 900        | 1800     | 1800           |
+      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "kubeletdown"   | 900      | 900        | 1800     | 1800           |
 
   @powerscale-vm-integration
   Scenario Outline: Basic node failover testing using test VM's (node interface down)

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -2026,15 +2026,15 @@ func (i *integration) writeAndVerifyDiskOnVM(vmName, namespace string) error {
 	retryDelay := 30 * time.Second
 
 	for attempt := 0; attempt <= retries; attempt++ {
-		log.Printf("Running (attempt %d/%d): %s", attempt+1, retries+1, writeCmd)
+		log.Printf("Running (attempt %d/%d): %s", attempt+1, retries, writeCmd)
 		writeOut, writeErr := exec.Command("bash", "-c", writeCmd).CombinedOutput()
 		if writeErr != nil {
-			log.Printf("Write failed on %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(writeOut))
+			log.Printf("Write failed on %s (attempt %d/%d): %s", vmName, attempt+1, retries, string(writeOut))
 			if attempt < retries {
 				time.Sleep(retryDelay)
 			}
 		} else {
-			log.Printf("Write output for %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(writeOut))
+			log.Printf("Write output for %s (attempt %d/%d): %s", vmName, attempt+1, retries, string(writeOut))
 			break
 		}
 	}
@@ -2060,15 +2060,15 @@ func (i *integration) verifyDiskContentOnVM(vmName, namespace string) error {
 	var readErr error
 
 	for attempt := 0; attempt <= retries; attempt++ {
-		log.Printf("Running (attempt %d/%d): %s", attempt+1, retries+1, readCmd)
+		log.Printf("Running (attempt %d/%d): %s", attempt+1, retries, readCmd)
 		readOut, readErr := exec.Command("bash", "-c", readCmd).CombinedOutput()
 		if readErr != nil {
-			log.Printf("Read failed on %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(readOut))
+			log.Printf("Read failed on %s (attempt %d/%d): %s", vmName, attempt+1, retries, string(readOut))
 			if attempt < retries {
 				time.Sleep(retryDelay)
 			}
 		} else {
-			log.Printf("Read output for %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(readOut))
+			log.Printf("Read output for %s (attempt %d/%d): %s", vmName, attempt+1, retries, string(readOut))
 			break
 		}
 	}

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -2020,13 +2020,28 @@ func (i *integration) writeAndVerifyDiskOnVM(vmName, namespace string) error {
 			"--local-ssh=true --local-ssh-opts='-o StrictHostKeyChecking=no' --local-ssh-opts='-o UserKnownHostsFile=/dev/null' "+
 			"--command \"printf '%s' | sudo dd of=/dev/vdc bs=1 count=150 conv=notrunc\"",
 		vmName, namespace, expectedData)
-	log.Printf("Running: %s", writeCmd)
-	writeOut, err := exec.Command("bash", "-c", writeCmd).CombinedOutput()
-	if err != nil {
-		log.Printf("Write failed on %s: %s", vmName, string(writeOut))
-		return err
+
+	var writeErr error
+	retries := 3
+	retryDelay := 30 * time.Second
+
+	for attempt := 0; attempt <= retries; attempt++ {
+		log.Printf("Running (attempt %d/%d): %s", attempt+1, retries+1, writeCmd)
+		writeOut, writeErr := exec.Command("bash", "-c", writeCmd).CombinedOutput()
+		if writeErr != nil {
+			log.Printf("Write failed on %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(writeOut))
+			if attempt < retries {
+				time.Sleep(retryDelay)
+			}
+		} else {
+			log.Printf("Write output for %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(writeOut))
+			break
+		}
 	}
-	log.Printf("Write output for %s: %s", vmName, string(writeOut))
+
+	if writeErr != nil {
+		return writeErr
+	}
 
 	// Read and verify
 	return i.verifyDiskContentOnVM(vmName, namespace)
@@ -2038,14 +2053,29 @@ func (i *integration) verifyDiskContentOnVM(vmName, namespace string) error {
 			"--local-ssh=true --local-ssh-opts='-o StrictHostKeyChecking=no'  --local-ssh-opts='-o UserKnownHostsFile=/dev/null' "+
 			"--command \"sudo dd if=/dev/vdc bs=1 count=150\"",
 		vmName, namespace)
-	log.Printf("Running: %s", readCmd)
-	readOut, err := exec.Command("bash", "-c", readCmd).CombinedOutput()
-	if err != nil {
-		log.Printf("Read failed on %s: %s", vmName, string(readOut))
-		return err
+
+	retries := 3
+	retryDelay := 30 * time.Second
+	var readOut []byte
+	var readErr error
+
+	for attempt := 0; attempt <= retries; attempt++ {
+		log.Printf("Running (attempt %d/%d): %s", attempt+1, retries+1, readCmd)
+		readOut, readErr := exec.Command("bash", "-c", readCmd).CombinedOutput()
+		if readErr != nil {
+			log.Printf("Read failed on %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(readOut))
+			if attempt < retries {
+				time.Sleep(retryDelay)
+			}
+		} else {
+			log.Printf("Read output for %s (attempt %d/%d): %s", vmName, attempt+1, retries+1, string(readOut))
+			break
+		}
 	}
 
-	log.Printf("Read output for %s: %s", vmName, string(readOut))
+	if readErr != nil {
+		return readErr
+	}
 
 	if strings.Contains(string(readOut), expectedData) {
 		log.Printf("Disk content verified for %s", vmName)


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
Add retry mechanism to VM read and write operation 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Executed make powerflex-vm-integration-test
```
RESILIENCY_VM_INT_TEST="true" \
RESILIENCY_TEST_CLEANUP="true" \
POLL_K8S="true" \
SCRIPTS_DIR="../../test/sh" \
go test -timeout 6h -test.v -test.run "^\QTestOcpVirtPowerFlexCheck\E|\QTestOcpVirtPowerFlexIntegration\E"
=== RUN   TestOcpVirtPowerFlexCheck
Feature: Virtual Machine Integration Test
  As a CSM for Resiliency developer
  I want to test OpenShift Virtualization with CSM for Resiliency in a OpenShift environment
  So that it is known to work on various vm clean up cases and give consistent results

  Scenario Outline: Validate that we have a valid k8s configuration for the Virtual Machine integration tests # features/virtualization.feature:7
    Given a kubernetes <kubeConfig>                                                                           # <autogenerated>:1 -> *integration
    Then Check OpenShift Virtualization is installed in the cluster                                           # <autogenerated>:1 -> *integration
    And test environmental variables are set                                                                  # <autogenerated>:1 -> *integration
    And these CSI driver <driverNames> are configured on the system                                           # <autogenerated>:1 -> *integration
    And these storageClasses <storageClasses> exist in the cluster                                            # <autogenerated>:1 -> *integration
    And there is a <namespace> in the cluster                                                                 # <autogenerated>:1 -> *integration
    And there are driver pods in <namespace> with this <name> prefix                                          # <autogenerated>:1 -> *integration
    And can logon to nodes and drop test scripts                                                              # <autogenerated>:1 -> *integration

    Examples:
      | kubeConfig | driverNames                | namespace  | name       | storageClasses |
      | ""         | "csi-vxflexos.dellemc.com" | "vxflexos" | "vxflexos" | "vxflexos"     |

1 scenarios (1 passed)
8 steps (8 passed)
33.69649095s
--- PASS: TestOcpVirtPowerFlexCheck (33.82s)
=== RUN   TestOcpVirtPowerFlexIntegration
Feature: Virtual Machine Integration Test
  As a CSM for Resiliency developer
  I want to test OpenShift Virtualization with CSM for Resiliency in a OpenShift environment
  So that it is known to work on various vm clean up cases and give consistent results

  Scenario Outline: Basic node failover testing using test VM's (node interface down)                                          # features/virtualization.feature:149
    Given a kubernetes <kubeConfig>                                                                                            # <autogenerated>:1 -> *integration
    And cluster is clean of test vms                                                                                           # <autogenerated>:1 -> *integration
    And wait <nodeCleanSecs> to see there are no taints                                                                        # <autogenerated>:1 -> *integration
    And <vmsPerNode> vms per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <deploySecs> seconds                                                        # <autogenerated>:1 -> *integration
    Then initial disk write and verify on all VMs succeeds                                                                     # <autogenerated>:1 -> *integration
    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds               # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <runSecs> seconds                                                           # <autogenerated>:1 -> *integration
    And labeled pods are on a different node                                                                                   # <autogenerated>:1 -> *integration
    Then post failover disk content verification on all VMs succeeds                                                           # <autogenerated>:1 -> *integration
    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds                                             # <autogenerated>:1 -> *integration
    Then finally cleanup everything                                                                                            # <autogenerated>:1 -> *integration

    Examples:
      | kubeConfig | vmsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 450      | 300        | 350     | 500           |
      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "interfacedown" | 500      | 400        | 500     | 650           |

  Scenario Outline: Basic node failover testing using test VM's (node slow reboots)                                            # features/virtualization.feature:169
    Given a kubernetes <kubeConfig>                                                                                            # <autogenerated>:1 -> *integration
    And cluster is clean of test vms                                                                                           # <autogenerated>:1 -> *integration
    And wait <nodeCleanSecs> to see there are no taints                                                                        # <autogenerated>:1 -> *integration
    And <vmsPerNode> vms per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <deploySecs> seconds                                                        # <autogenerated>:1 -> *integration
    Then initial disk write and verify on all VMs succeeds                                                                     # <autogenerated>:1 -> *integration
    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds               # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <runSecs> seconds                                                           # <autogenerated>:1 -> *integration
    And labeled pods are on a different node                                                                                   # <autogenerated>:1 -> *integration
    Then post failover disk content verification on all VMs succeeds                                                           # <autogenerated>:1 -> *integration
    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds                                             # <autogenerated>:1 -> *integration
    Then finally cleanup everything                                                                                            # <autogenerated>:1 -> *integration

    Examples:
      | kubeConfig | vmsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure  | failSecs | deploySecs | runSecs | nodeCleanSecs |
      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 600      | 600        | 1800    | 1800          |
      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "reboot" | 900      | 900        | 1800    | 1800          |

  Scenario Outline: Basic node failover testing using test VM's (node kubelet down)                                            # features/virtualization.feature:189
    Given a kubernetes <kubeConfig>                                                                                            # <autogenerated>:1 -> *integration
    And cluster is clean of test vms                                                                                           # <autogenerated>:1 -> *integration
    And wait <nodeCleanSecs> to see there are no taints                                                                        # <autogenerated>:1 -> *integration
    And <vmsPerNode> vms per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <deploySecs> seconds                                                        # <autogenerated>:1 -> *integration
    Then initial disk write and verify on all VMs succeeds                                                                     # <autogenerated>:1 -> *integration
    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds               # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <runSecs> seconds                                                           # <autogenerated>:1 -> *integration
    And labeled pods are on a different node                                                                                   # <autogenerated>:1 -> *integration
    Then post failover disk content verification on all VMs succeeds                                                           # <autogenerated>:1 -> *integration
    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds                                             # <autogenerated>:1 -> *integration
    Then finally cleanup everything                                                                                            # <autogenerated>:1 -> *integration

    Examples:
      | kubeConfig | vmsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure       | failSecs | deploySecs | runSecs | nodeCleanSecs |
      | ""         | "1-1"      | "0-0" | "1-1" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "kubeletdown" | 600      | 900        | 1800    | 1800          |
      | ""         | "2-2"      | "0-0" | "2-2" | "vxflexos" | "vxflexos"   | "one-third" | "zero"  | "kubeletdown" | 900      | 900        | 1800    | 1800          |

6 scenarios (6 passed)
72 steps (72 passed)
1h31m28.542121986s
--- PASS: TestOcpVirtPowerFlexIntegration (5488.61s)
PASS
status 0
ok  	podmon/internal/monitor	5522.610s
```