### PR TITLE
Fix: Driver Controller Pod Determination

### DIFF
--- a/internal/monitor/features/integration.feature
+++ b/internal/monitor/features/integration.feature
@@ -182,10 +182,10 @@ Feature: Integration Test
     Then finally cleanup everything
 
     Examples:
-      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass  | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
+      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
      # Small number of pods, increasing number of vols and devs
-      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"    | "isilon" | "one-third" | "zero"  | "interfacedown" | 900      | 900        | 900     | 900           |
-      | ""         | "3-5"       | "2-2" | "0-0" | "isilon"    | "isilon" | "one-third" | "zero"  | "interfacedown" | 900      | 900        | 900     | 900           |
+      | ""         | "1-2"       | "1-1" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "interfacedown" | 120      | 900        | 900     | 900           |
+      | ""         | "3-5"       | "2-2" | "0-0" | "isilon"   | "isilon"     | "one-third" | "zero"  | "interfacedown" | 240      | 900        | 900     | 900           |
   
   @powerstore-integration @powerstore-sanity-test
   Scenario Outline: Basic node failover testing using test StatefulSet pods (node interface down)

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -1868,9 +1868,14 @@ func (i *integration) failNodes(filter func(node corev1.Node) bool, count float6
 	}
 
 	if int(*deployment.Spec.Replicas) == 1 {
+
+		label := "name=" + i.driverType + "-controller"
+		if i.driverType == "isilon" {
+			label = "app=" + i.driverType + "-controller"
+		}
 		// If there is only one replica, get node that the controller pod is running on and ensure that we don't fail it.
 		controllerPod, err := i.k8s.GetClient().CoreV1().Pods(i.driverType).List(context.Background(), metav1.ListOptions{
-			LabelSelector: "name=" + i.driverType + "-controller",
+			LabelSelector: label,
 		})
 		if err != nil {
 			return failedNodes, err

--- a/internal/monitor/integration_steps_test.go
+++ b/internal/monitor/integration_steps_test.go
@@ -1882,7 +1882,7 @@ func (i *integration) failNodes(filter func(node corev1.Node) bool, count float6
 
 		for _, pod := range driverPods.Items {
 			if strings.Contains(pod.Name, expectedControllerPodName) {
-				log.Infof("[FERNANDO] Controller pod is running on node %s", pod.Spec.NodeName)
+				log.Infof("Controller pod is running on node %s", pod.Spec.NodeName)
 				i.shouldNotFailNode = pod.Spec.NodeName
 				break
 			}


### PR DESCRIPTION
<!--
 Copyright (c) 2021-2022 Dell Inc., or its subsidiaries. All Rights Reserved.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

 http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->
# Description
It was identified that the labels for controller pods can be different between different drivers. This causes an issue when determining the controller pod for the driver.

For this reason, we changed the way in which the controller pod is identified because we can guarantee that it will always contain `<driverType>-controller`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensured that this worked with PowerStore as it was previously.
- [x] Ensured that this works with PowerScale as the label is different.
```
2 scenarios (2 passed)
20 steps (20 passed)
16m39.338139204s
INFO[1059] Integration test finished
--- PASS: TestPowerScaleIntegration (999.35s)
PASS
status 0
ok      podmon/internal/monitor 1059.053
```
- [x] Ensured that this works with Powermax as well 

```
    Given a kubernetes <kubeConfig>                                                                                              # <autogenerated>:1 -> *integration
    And cluster is clean of test pods                                                                                            # <autogenerated>:1 -> *integration
    And wait <nodeCleanSecs> to see there are no taints                                                                          # <autogenerated>:1 -> *integration
    And <podsPerNode> pods per node with <nVol> volumes and <nDev> devices using <driverType> and <storageClass> in <deploySecs> # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <deploySecs> seconds                                                          # <autogenerated>:1 -> *integration
    When I fail <workers> worker nodes and <primary> primary nodes with <failure> failure for <failSecs> seconds                 # <autogenerated>:1 -> *integration
    Then validate that all pods are running within <runSecs> seconds                                                             # <autogenerated>:1 -> *integration
    And labeled pods are on a different node                                                                                     # <autogenerated>:1 -> *integration
    And the taints for the failed nodes are removed within <nodeCleanSecs> seconds                                               # <autogenerated>:1 -> *integration
    Then finally cleanup everything                                                                                              # <autogenerated>:1 -> *integration

    Examples:
      | kubeConfig | podsPerNode | nVol  | nDev  | driverType | storageClass     | workers     | primary | failure         | failSecs | deploySecs | runSecs | nodeCleanSecs |
      | ""         | "1-1"       | "1-1" | "0-0" | "powermax" | "powermax-iscsi" | "one-third" | "zero"  | "interfacedown" | 120      | 240        | 300     | 300           |

1 scenarios (1 passed)
10 steps (10 passed)
5m37.845384299s
INFO[0350] Integration test finished                    
--- PASS: TestPowerMaxShortIntegration (337.88s)
PASS
status 0
ok      podmon/internal/monitor 350.053s

```

- [x]  Ensured that this works with PowerFlex
```
3 scenarios (3 passed)
30 steps (30 passed)
25m54.877932009s
INFO[1612] Integration test finished
--- PASS: TestPowerFlexIntegration (1554.89s)
PASS
status 0
ok      podmon/internal/monitor 1612.446s
```